### PR TITLE
falcoctl install probe

### DIFF
--- a/cmd/falco_install.go
+++ b/cmd/falco_install.go
@@ -51,6 +51,7 @@ func NewFalcoInstallCommand(streams genericclioptions.IOStreams, f factory.Facto
 
 	cmd := &cobra.Command{
 		Use:                   "falco",
+		TraverseChildren:      true,
 		DisableFlagsInUseLine: true,
 		Short:                 "Install Falco in Kubernetes",
 		Long:                  `Deploy Falco to Kubernetes`,

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -45,12 +45,14 @@ func NewInstallCommand(streams genericclioptions.IOStreams, f factory.Factory) *
 
 	cmd := &cobra.Command{
 		Use:                   "install",
+		TraverseChildren:      true,
 		DisableFlagsInUseLine: true,
 		Short:                 "Install a component wih falcoctl",
 		Long:                  `Install a component wih falcoctl`,
 	}
 
 	cmd.AddCommand(NewFalcoInstallCommand(streams, f))
+	cmd.AddCommand(NewProbeInstallCommand(streams))
 
 	return cmd
 }

--- a/cmd/probe_install.go
+++ b/cmd/probe_install.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"path"
 
 	"github.com/falcosecurity/falcoctl/pkg/probeloader"
@@ -107,14 +106,14 @@ func NewProbeInstallCommand(streams genericclioptions.IOStreams) *cobra.Command 
 			// fetch module
 			err = probeloader.FetchModule(o.falcoProbeURL, falcoProbeFullpath)
 			if err != nil {
-				log.Fatalf("Error fetching module: %s", err)
+				logger.Critical("Error fetching module: %s", err)
 			}
 
 			// load module
 			// TODO(ducy): Need to implement removal of module, retry loop, and timeout
 			err = probeloader.LoadModule(falcoProbeFullpath)
 			if err != nil {
-				log.Fatalf("Error loading module: %s", err)
+				logger.Critical("Error loading module: %s", err)
 			}
 
 			return nil

--- a/cmd/probe_install.go
+++ b/cmd/probe_install.go
@@ -1,0 +1,131 @@
+/*
+Copyright © 2019 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"path"
+
+	"github.com/falcosecurity/falcoctl/pkg/probeloader"
+	"github.com/kris-nova/logger"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+// ProbeInstallOptions represents the `install probe` command options
+type ProbeInstallOptions struct {
+	genericclioptions.IOStreams
+	falcoVersion   string
+	falcoProbePath string
+	falcoProbeFile string
+	falcoProbeURL  string
+	falcoProbeRepo string
+}
+
+// Validate validates the `install probe` command options
+func (o ProbeInstallOptions) Validate(c *cobra.Command, args []string) error {
+	return nil
+}
+
+// NewProbeInstallOptions instantiates the `install probe` command options
+func NewProbeInstallOptions(streams genericclioptions.IOStreams) CommandOptions {
+	o := &ProbeInstallOptions{
+		IOStreams: streams,
+	}
+	o.falcoVersion = viper.GetString("falco-version")
+	if len(o.falcoVersion) == 0 {
+		o.falcoVersion = "0.17.1"
+	}
+	o.falcoProbePath = viper.GetString("falco-probe-path")
+	if len(o.falcoProbePath) == 0 {
+		o.falcoProbePath = "/"
+	}
+	o.falcoProbeFile = viper.GetString("falco-probe-file")
+	if len(o.falcoProbeFile) == 0 {
+		o.falcoProbeFile = "falco-probe.ko"
+	}
+	o.falcoProbeURL = viper.GetString("falco-probe-url")
+	if len(o.falcoProbeURL) == 0 {
+		o.falcoProbeURL = ""
+	}
+	o.falcoProbeRepo = viper.GetString("falco-probe-repo")
+	if len(o.falcoProbeRepo) == 0 {
+		o.falcoProbeRepo = "https://s3.amazonaws.com/download.draios.com/stable/sysdig-probe-binaries/"
+	}
+	return o
+}
+
+// NewProbeInstallCommand creates the `install probe` command
+func NewProbeInstallCommand(streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewProbeInstallOptions(streams).(*ProbeInstallOptions)
+
+	cmd := &cobra.Command{
+		Use:                   "probe",
+		DisableFlagsInUseLine: true,
+		Short:                 "Install the Falco probe locally",
+		Long:                  `Download and install the Falco module locally`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			falcoProbeFullpath := path.Join(o.falcoProbePath, o.falcoProbeFile)
+			falcoConfigHash, err := probeloader.GetKernelConfigHash()
+			if err != nil {
+				logger.Critical("Error getting Kernel Config Hash: %s", err)
+				return err
+			}
+			falcoKernelRelease, err := probeloader.GetKernelRelease()
+			if err != nil {
+				logger.Critical("Error getting Kernel Version: %s", err)
+				return err
+			}
+
+			logger.Always("FALCO_VERSION: %s", o.falcoVersion)
+			logger.Always("FALCO_PROBE_URL: %s", o.falcoProbeURL)
+			logger.Always("FALCO_PROBE_REPO: %s", o.falcoProbeRepo)
+			logger.Always("KERNEL_VERSION: %s", falcoKernelRelease)
+			logger.Always("KERNEL_CONFIG_HASH: %s", falcoConfigHash)
+
+			// if FALCO_PROBE_URL not set, build it
+			if o.falcoProbeURL == "" {
+				o.falcoProbeURL = fmt.Sprintf("%sfalco-probe-%s-x86_64-%s-%s.ko", o.falcoProbeRepo, o.falcoVersion, falcoKernelRelease, falcoConfigHash)
+			}
+
+			// fetch module
+			err = probeloader.FetchModule(o.falcoProbeURL, falcoProbeFullpath)
+			if err != nil {
+				log.Fatalf("Error fetching module: %s", err)
+			}
+
+			// load module
+			// TODO(ducy): Need to implement removal of module, retry loop, and timeout
+			err = probeloader.LoadModule(falcoProbeFullpath)
+			if err != nil {
+				log.Fatalf("Error loading module: %s", err)
+			}
+
+			return nil
+		},
+	}
+
+	// TODO(fntlnz, leodido): validation
+	cmd.Flags().StringVar(&o.falcoVersion, "falco-version", o.falcoVersion, "The falco version for which to download the probe")
+	cmd.Flags().StringVar(&o.falcoProbePath, "falco-probe-path", o.falcoProbePath, "The path where to download the falco probe")
+	cmd.Flags().StringVar(&o.falcoProbeFile, "falco-probe-file", o.falcoProbeFile, "The name of the falco probe file")
+	cmd.Flags().StringVar(&o.falcoProbeURL, "falco-probe-url", o.falcoProbeURL, "The direct URL where to download the falco probe from, alternative to the repo, not the default, this skips the search since a direct url is provided")
+	cmd.Flags().StringVar(&o.falcoProbeRepo, "falco-probe-repo", o.falcoProbeRepo, "The URL of the s3 repo where to search for the probe")
+	return cmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,11 +17,14 @@ limitations under the License.
 package cmd
 
 import (
+	"strings"
+
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/falcosecurity/falcoctl/pkg/kubernetes/factory"
 	"github.com/kris-nova/logger"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // RootOptions represents the base command options
@@ -69,12 +72,16 @@ func NewRootCommand(streams genericclioptions.IOStreams) *cobra.Command {
 
 	cmd.PersistentFlags().BoolVarP(&o.fabulous, "fab", "f", o.fabulous, "Enable rainbow logs")
 
-	flags := cmd.PersistentFlags()
+	flags := cmd.Flags()
 	o.configFlags.AddFlags(flags)
 
 	matchVersionFlags := factory.NewMatchVersionFlags(o.configFlags)
 	matchVersionFlags.AddFlags(flags)
 	f := factory.NewFactory(matchVersionFlags)
+
+	viper.AutomaticEnv()
+	viper.SetEnvPrefix("falcoctl")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 
 	cmd.AddCommand(NewInstallCommand(streams, f))
 	cmd.AddCommand(NewDeleteCommand(streams, f))

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,9 @@ require (
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.3
+	github.com/spf13/viper v1.3.2
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
+	golang.org/x/sys v0.0.0-20191008105621-543471e840be
 	golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/api v0.0.0-20190409021203-6e4e0e4f393b

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 cloud.google.com/go v0.34.0 h1:eOI3/cP2VTU6uZLDYAoic+eyzzB9YyGmJ7eIjl8rOPg=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0 h1:0GoNN3taZV6QI81IXgCbxMyEaJDXMSIjArYBCYzVVvs=
@@ -70,6 +71,7 @@ github.com/googleapis/gnostic v0.3.1 h1:WeAefnSUHlBb0iJKwxFDZdbfGwkd7xRNuV+IpXMJ
 github.com/googleapis/gnostic v0.3.1/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
+github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/imdario/mergo v0.3.8 h1:CGgOkSJeqMRmt0D9XLWExdT4m4F1vd3FV3VPt+0VxkQ=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
@@ -90,6 +92,7 @@ github.com/kris-nova/logger v0.0.0-20181127235838-fd0d87064b06 h1:vN4d3jSss3ExzU
 github.com/kris-nova/logger v0.0.0-20181127235838-fd0d87064b06/go.mod h1:++9BgZujZd4v0ZTZCb5iPsaomXdZWyxotIAh1IiDm44=
 github.com/kris-nova/lolgopher v0.0.0-20180921204813-313b3abb0d9b h1:xYEM2oBUhBEhQjrV+KJ9lEWDWYZoNVZUaBF++Wyljq4=
 github.com/kris-nova/lolgopher v0.0.0-20180921204813-313b3abb0d9b/go.mod h1:V0HF/ZBlN86HqewcDC/cVxMmYDiRukWjSrgKLUAn9Js=
+github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a h1:TpvdAwDAt1K4ANVOfcihouRdvP+MgAfDWwBuct4l6ZY=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -103,6 +106,7 @@ github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW1
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -117,6 +121,7 @@ github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c h1:Hww8mOyEKTeON4bZn7F
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c h1:eSfnfIuwhxZyULg1NNuZycJcYkjYVGYe7FczwQReM6U=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
+github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
@@ -126,14 +131,18 @@ github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
+github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.5 h1:f0B+LkLX6DtmRH1isoNA9VTtNUK9K8xYd28JNNfOv/s=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
+github.com/spf13/jwalterweatherman v1.0.0 h1:XHEdyB+EcvlqZamSM4ZOMGlc93t6AcsBEu9Gc1vn7yk=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/viper v1.3.2 h1:VUFqw5KcqRf7i70GOzW7N+Q7+gxVBkSSqiXB12+JQ4M=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=

--- a/main.go
+++ b/main.go
@@ -19,12 +19,15 @@ import (
 	"os"
 
 	"github.com/falcosecurity/falcoctl/cmd"
+	"github.com/spf13/pflag"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 )
 
 func main() {
+	flags := pflag.NewFlagSet("falcoctl", pflag.ExitOnError)
+	pflag.CommandLine = flags
 	root := cmd.NewRootCommand(genericclioptions.IOStreams{
 		In:     os.Stdin,
 		Out:    os.Stdout,

--- a/pkg/probeloader/loader.go
+++ b/pkg/probeloader/loader.go
@@ -132,7 +132,7 @@ func LoadModule(path string) error {
 		return err
 	}
 
-	logger.Always("Opened probe: ", path)
+	logger.Always("Opened probe: %s", path)
 
 	p0, err := unix.BytePtrFromString("")
 

--- a/pkg/probeloader/loader.go
+++ b/pkg/probeloader/loader.go
@@ -1,0 +1,145 @@
+package probeloader
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/md5"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"os"
+	"unsafe"
+
+	"github.com/kris-nova/logger"
+	"golang.org/x/sys/unix"
+)
+
+// GetKernelRelease gets the current kernel release
+func GetKernelRelease() (release string, err error) {
+	name := &unix.Utsname{}
+	err = unix.Uname(name)
+	if err != nil {
+		return release, err
+	}
+	release = string(name.Release[:bytes.IndexByte(name.Release[:], 0)])
+	return release, err
+}
+
+// GetKernelConfigHash gets the hash of the current kernel's configuration
+func GetKernelConfigHash() (string, error) {
+	var hash string
+	kernelConfigPath, err := getKernelConfigPath()
+	if err != nil {
+		return hash, err
+	}
+	hash, err = genKernelConfigHash(kernelConfigPath)
+	if err != nil {
+		return hash, err
+	}
+	return hash, err
+}
+
+func getKernelConfigPath() (string, error) {
+	var err error
+	kernelConfigPath := ""
+
+	version, _ := GetKernelRelease()
+	paths := []string{
+		"/proc/config.gz",
+		"/boot/config-" + version,
+		"/host/boot/config-" + version,
+		"/usr/lib/ostree-boot/config-" + version,
+		"/usr/lib/ostree-boot/config-" + version,
+		"/lib/modules/" + version + "/config"}
+
+	for _, path := range paths {
+		_, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		return path, err
+	}
+	return kernelConfigPath, err
+}
+
+func genKernelConfigHash(path string) (string, error) {
+	var md5hash string
+	var err error
+
+	file, err := os.Open(path)
+	if err != nil {
+		return md5hash, err
+	}
+	defer file.Close()
+
+	fileBuf := bytes.NewBuffer(nil)
+	io.Copy(fileBuf, file)
+
+	filetype := http.DetectContentType(fileBuf.Bytes())
+
+	if filetype == "application/x-gzip" {
+		gzipFile, err := gzip.NewReader(fileBuf)
+		if err != nil {
+			return md5hash, err
+		}
+		defer gzipFile.Close()
+		fileBuf = bytes.NewBuffer(nil)
+		io.Copy(fileBuf, gzipFile)
+	}
+
+	hash := md5.New()
+	if _, err := io.Copy(hash, fileBuf); err != nil {
+		return md5hash, err
+	}
+
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+// FetchModule looks for the Falco module and downloads it if found
+func FetchModule(url string, path string) error {
+	logger.Always("Downloading kernel module from %s", url)
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	logger.Always("Recevied HTTP Status Code: %d", resp.StatusCode)
+	if resp.StatusCode == http.StatusOK {
+		out, err := os.Create(path)
+		if err != nil {
+			logger.Critical("Error creating file: %s", path)
+			return err
+		}
+		defer out.Close()
+
+		_, err = io.Copy(out, resp.Body)
+		if err != nil {
+			logger.Critical("Unable to write file: %s", path)
+			return err
+		}
+		logger.Always("Wrote kernel module: %s", path)
+	} else {
+		logger.Critical("Non-200 Status code received %d", resp.StatusCode)
+	}
+	return err
+}
+
+// LoadModule loads the falco kernel module into the current kernel
+func LoadModule(path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		logger.Critical("Error opening kernel module: %s", path)
+		return err
+	}
+
+	logger.Always("Opened probe: ", path)
+
+	p0, err := unix.BytePtrFromString("")
+
+	if _, _, err := unix.Syscall(313, file.Fd(), uintptr(unsafe.Pointer(p0)), 0); err != 0 {
+		logger.Critical("Error loading kernel module: %s. The module may already be loaded.", path)
+		return err
+	}
+
+	return err
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area library

/area cli


**What this PR does / why we need it**:

This PR ports the `httploader` tool from this PR on Falco https://github.com/falcosecurity/falco/pull/776 to the falcoctl under the form of `falcoctl install probe`. This tool will figure out how to download the pre-built Falco probe for this kernel (the kernel module) and load it.

**Which issue(s) this PR fixes**:

Fixes #20 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
cli: new command falcoctl install probe
```
