### PR TITLE
Add a prefix to all generated lists/rules

### DIFF
--- a/cmd/psp_conv.go
+++ b/cmd/psp_conv.go
@@ -85,7 +85,7 @@ func convertPspFalcoRules(pspPath string, rulesPath string) error {
 
 	psp, err := ioutil.ReadAll(pspFile)
 
-	conv, err := converter.NewConverter(debugLog, infoLog, errorLog)
+	conv, err := converter.NewConverter("", debugLog, infoLog, errorLog)
 	if err != nil {
 		return fmt.Errorf("Could not create converter: %v", err)
 	}

--- a/pkg/converter/psp/k8s_psp_rules_template.go
+++ b/pkg/converter/psp/k8s_psp_rules_template.go
@@ -20,60 +20,60 @@ var (
 	K8sPspRulesTemplate string = `
 - required_engine_version: 5
 
-- list: psp_images
+- list: {{ .NamePrefix }}_psp_images
   items: {{index .Annotations "falco-rules-psp-images"}}
 
 # K8s audit specific macros here
-- macro: psp_ka_always_true
+- macro: {{ .NamePrefix }}_psp_ka_always_true
   condition: (jevt.rawtime exists)
 
-- macro: psp_ka_never_true
+- macro: {{ .NamePrefix }}_psp_ka_never_true
   condition: (jevt.rawtime=0)
 
-- macro: psp_ka_enabled
-  condition: (psp_ka_always_true)
+- macro: {{ .NamePrefix }}_psp_ka_enabled
+  condition: ({{ .NamePrefix }}_psp_ka_always_true)
 
-- macro: psp_kevt
+- macro: {{ .NamePrefix }}_psp_kevt
   condition: (jevt.value[/stage] in ("ResponseComplete"))
 
-- macro: psp_ka_pod
+- macro: {{ .NamePrefix }}_psp_ka_pod
   condition: (ka.target.resource=pods and not ka.target.subresource exists)
 
-- macro: psp_ka_container
-  condition: (psp_ka_enabled and psp_kevt and psp_ka_pod and ka.verb=create and ka.req.pod.containers.image.repository in (psp_images))
+- macro: {{ .NamePrefix }}_psp_ka_container
+  condition: ({{ .NamePrefix }}_psp_ka_enabled and {{ .NamePrefix }}_psp_kevt and {{ .NamePrefix }}_psp_ka_pod and ka.verb=create and ka.req.pod.containers.image.repository in ({{ .NamePrefix }}_psp_images))
 
 # syscall audit specific macros here
-- macro: psp_always_true
+- macro: {{ .NamePrefix }}_psp_always_true
   condition: (evt.num>=0)
 
-- macro: psp_never_true
+- macro: {{ .NamePrefix }}_psp_never_true
   condition: (evt.num=0)
 
-- macro: psp_enabled
-  condition: (psp_always_true)
+- macro: {{ .NamePrefix }}_psp_enabled
+  condition: ({{ .NamePrefix }}_psp_always_true)
 
-- macro: psp_container
-  condition: (psp_enabled and container.image.repository in (psp_images))
+- macro: {{ .NamePrefix }}_psp_container
+  condition: ({{ .NamePrefix }}_psp_enabled and container.image.repository in ({{ .NamePrefix }}_psp_images))
 
-- macro: psp_open_write
+- macro: {{ .NamePrefix }}_psp_open_write
   condition: (evt.type=open or evt.type=openat) and evt.is_open_write=true and fd.typechar='f' and fd.num>=0
 
 {{ if not .Spec.Privileged }}
 #########################################
 # Rule(s) for PSP privileged property
 #########################################
-- rule: PSP Violation (privileged) K8s Audit
+- rule: PSP {{ .NamePrefix }} Violation (privileged) K8s Audit
   desc: >
     Detect a psp validation failure for a privileged pod using k8s audit logs
-  condition: psp_ka_container and ka.req.pod.containers.privileged intersects (true)
+  condition: {{ .NamePrefix }}_psp_ka_container and ka.req.pod.containers.privileged intersects (true)
   output: Pod Security Policy {{ .Name }} validation failure--pod with privileged=true (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace images=%ka.req.pod.containers.image spec=%jevt.value[/requestObject/spec])
   priority: WARNING
   source: k8s_audit
   tags: [k8s-psp]
 
-- rule: PSP Violation (privileged) System Activity
+- rule: PSP {{ .NamePrefix }} Violation (privileged) System Activity
   desc: Detect a psp validation failure for a privileged pod using syscalls
-  condition: psp_container and evt.type=container and container.privileged intersects (true)
+  condition: {{ .NamePrefix }}_psp_container and evt.type=container and container.privileged intersects (true)
   output: Pod Security Policy {{ .Name }} validation failure--container with privileged=true created (user=%user.name command=%proc.cmdline %container.info images=%container.image.repository:%container.image.tag)
   priority: WARNING
   source: syscall
@@ -83,10 +83,10 @@ var (
 #########################################
 # Rule(s) for PSP hostPID property
 #########################################
-- rule: PSP Violation (hostPID)
+- rule: PSP {{ .NamePrefix }} Violation (hostPID)
   desc: >
     Detect a psp validation failure for a hostPID pod using k8s audit logs
-  condition: psp_ka_container and ka.req.pod.host_pid intersects (true)
+  condition: {{ .NamePrefix }}_psp_ka_container and ka.req.pod.host_pid intersects (true)
   output: Pod Security Policy {{ .Name }} validation failure--pod with hostpid=true (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace images=%ka.req.pod.containers.image spec=%jevt.value[/requestObject/spec])
   priority: WARNING
   source: k8s_audit
@@ -95,10 +95,10 @@ var (
 #########################################
 # Rule(s) for PSP hostIPC property
 #########################################
-- rule: PSP Violation (hostIPC)
+- rule: PSP {{ .NamePrefix }} Violation (hostIPC)
   desc: >
     Detect a psp validation failure for a hostIPC pod using k8s audit logs
-  condition: psp_ka_container and ka.req.pod.host_ipc intersects (true)
+  condition: {{ .NamePrefix }}_psp_ka_container and ka.req.pod.host_ipc intersects (true)
   output: Pod Security Policy {{ .Name }} validation failure--pod with hostipc=true (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace images=%ka.req.pod.containers.image spec=%jevt.value[/requestObject/spec])
   priority: WARNING
   source: k8s_audit
@@ -107,10 +107,10 @@ var (
 #########################################
 # Rule(s) for PSP hostNetwork property
 #########################################
-- rule: PSP Violation (hostNetwork)
+- rule: PSP {{ .NamePrefix }} Violation (hostNetwork)
   desc: >
     Detect a psp validation failure for a hostNetwork pod using k8s audit logs
-  condition: psp_ka_container and ka.req.pod.host_network intersects (true)
+  condition: {{ .NamePrefix }}_psp_ka_container and ka.req.pod.host_network intersects (true)
   output: Pod Security Policy {{ .Name }} validation failure--pod with hostnetwork=true (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace images=%ka.req.pod.containers.image spec=%jevt.value[/requestObject/spec])
   priority: WARNING
   source: k8s_audit
@@ -119,10 +119,10 @@ var (
 #########################################
 # Rule(s) for PSP hostPorts ranges
 #########################################
-- rule: PSP Violation (hostPorts)
+- rule: PSP {{ .NamePrefix }} Violation (hostPorts)
   desc: >
     Detect a psp validation failure for a hostnetwork port outside of the allowed set using k8s audit logs
-  condition: psp_ka_container and not ka.req.pod.containers.host_port in ({{ JoinHostPortRanges .Spec.HostPorts }},"<NA>")
+  condition: {{ .NamePrefix }}_psp_ka_container and not ka.req.pod.containers.host_port in ({{ JoinHostPortRanges .Spec.HostPorts }},"<NA>")
   output: Pod Security Policy {{ .Name }} validation failure--hostnetwork port outside of allowed ranges ({{ JoinHostPortRanges .Spec.HostPorts }}) (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace images=%ka.req.pod.containers.image spec=%jevt.value[/requestObject/spec])
   priority: WARNING
   source: k8s_audit
@@ -131,10 +131,10 @@ var (
 #########################################
 # Rule(s) for PSP volumes property
 #########################################
-- rule: PSP Violation (volumes)
+- rule: PSP {{ .NamePrefix }} Violation (volumes)
   desc: >
     Detect a psp validation failure for a volume type outside of the allowed set using k8s audit logs
-  condition: psp_ka_container and not ka.req.pod.volumes.volume_type in ({{ JoinFSTypes .Spec.Volumes}},"<NA>")
+  condition: {{ .NamePrefix }}_psp_ka_container and not ka.req.pod.volumes.volume_type in ({{ JoinFSTypes .Spec.Volumes}},"<NA>")
   output: Pod Security Policy {{ .Name }} validation failure--volume type outside of allowed set ({{ JoinFSTypes .Spec.Volumes }}) (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace images=%ka.req.pod.containers.image spec=%jevt.value[/requestObject/spec])
   priority: WARNING
   source: k8s_audit
@@ -143,10 +143,10 @@ var (
 #########################################
 # Rule(s) for PSP allowedHostPaths property
 #########################################
-- rule: PSP Violation (allowedHostPaths)
+- rule: PSP {{ .NamePrefix }} Violation (allowedHostPaths)
   desc: >
     Detect a psp validation failure for a hostPath volume with a path outside of the allowed set using k8s audit logs
-  condition: psp_ka_container and not ka.req.pod.volumes.hostpath pmatch ({{ JoinHostPaths .Spec.AllowedHostPaths }},"<NA>")
+  condition: {{ .NamePrefix }}_psp_ka_container and not ka.req.pod.volumes.hostpath pmatch ({{ JoinHostPaths .Spec.AllowedHostPaths }},"<NA>")
   output: Pod Security Policy {{ .Name }} validation failure--hostPath volume mounting path outside of allowed set ({{ JoinHostPaths .Spec.AllowedHostPaths }}) (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace images=%ka.req.pod.containers.image spec=%jevt.value[/requestObject/spec])
   priority: WARNING
   source: k8s_audit
@@ -155,10 +155,10 @@ var (
 #########################################
 # Rule(s) for PSP allowedFlexVolumes property
 #########################################
-- rule: PSP Violation (allowedFlexVolumes)
+- rule: PSP {{ .NamePrefix }} Violation (allowedFlexVolumes)
   desc: >
     Detect a psp validation failure for a FlexVolume driver outside of the allowed set using k8s audit logs
-  condition: psp_ka_container and not ka.req.pod.volumes.flexvolume_driver in ({{JoinFlexvolumes .Spec.AllowedFlexVolumes}},"<NA>")
+  condition: {{ .NamePrefix }}_psp_ka_container and not ka.req.pod.volumes.flexvolume_driver in ({{JoinFlexvolumes .Spec.AllowedFlexVolumes}},"<NA>")
   output: Pod Security Policy {{ .Name }} validation failure--Flexvolume driver outside of allowed set ({{JoinFlexvolumes .Spec.AllowedFlexVolumes}}) (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace images=%ka.req.pod.containers.image spec=%jevt.value[/requestObject/spec])
   priority: WARNING
   source: k8s_audit
@@ -167,21 +167,21 @@ var (
 #########################################
 # Rule(s) for PSP fsGroup property
 #########################################
-- macro: psp_fs_group_must_run_matches
+- macro: {{ .NamePrefix }}_psp_fs_group_must_run_matches
 {{ if eq .Spec.FSGroup.Rule "MustRunAs" }}  condition: ka.req.pod.fs_group in ({{ JoinIDRanges .Spec.FSGroup.Ranges }})
-{{ else }}  condition: (psp_ka_always_true)
+{{ else }}  condition: ({{ .NamePrefix }}_psp_ka_always_true)
 {{ end }}
-- macro: psp_fs_group_may_run_matches
+- macro: {{ .NamePrefix }}_psp_fs_group_may_run_matches
 {{ if eq .Spec.FSGroup.Rule "MayRunAs" }}  condition: ka.req.pod.fs_group in ({{ JoinIDRanges .Spec.FSGroup.Ranges }},"<NA>")
-{{ else }}  condition: (psp_ka_always_true)
+{{ else }}  condition: ({{ .NamePrefix }}_psp_ka_always_true)
 {{ end }}
-- macro: psp_fs_group
-  condition: (psp_fs_group_must_run_matches and psp_fs_group_may_run_matches)
+- macro: {{ .NamePrefix }}_psp_fs_group
+  condition: ({{ .NamePrefix }}_psp_fs_group_must_run_matches and {{ .NamePrefix }}_psp_fs_group_may_run_matches)
 
-- rule: PSP Violation (fsGroup)
+- rule: PSP {{ .NamePrefix }} Violation (fsGroup)
   desc: >
     Detect a psp validation failure for a fsGroup gid outside of the allowed set using k8s audit logs
-  condition: psp_ka_container and not psp_fs_group
+  condition: {{ .NamePrefix }}_psp_ka_container and not {{ .NamePrefix }}_psp_fs_group
   output: Pod Security Policy {{ .Name }} validation failure--fsGroup outside of allowed set. Rule={{ .Spec.FSGroup.Rule}} ranges= ({{ JoinIDRanges .Spec.FSGroup.Ranges }}) (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace images=%ka.req.pod.containers.image spec=%jevt.value[/requestObject/spec])
   priority: WARNING
   source: k8s_audit
@@ -190,19 +190,19 @@ var (
 #########################################
 # Rule(s) for PSP readOnlyRootFilesystem property
 #########################################
-- rule: PSP Violation (readOnlyRootFilesystem) K8s Audit
+- rule: PSP {{ .NamePrefix }} Violation (readOnlyRootFilesystem) K8s Audit
   desc: >
     Detect a psp validation failure for a readOnlyRootFilesystem pod using k8s audit logs
-  condition: psp_ka_container and not ka.req.pod.containers.read_only_fs in (true)
+  condition: {{ .NamePrefix }}_psp_ka_container and not ka.req.pod.containers.read_only_fs in (true)
   output: Pod Security Policy {{ .Name }} validation failure--pod without readOnlyRootFilesystem=true (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace images=%ka.req.pod.containers.image spec=%jevt.value[/requestObject/spec])
   priority: WARNING
   source: k8s_audit
   tags: [k8s-psp]
 
-- rule: PSP Violation (readOnlyRootFilesystem) System Activity
+- rule: PSP {{ .NamePrefix }} Violation (readOnlyRootFilesystem) System Activity
   desc: >
     Detect a psp validation failure for a readOnlyRootFilesystem pod using syscalls
-  condition: psp_container and psp_open_write
+  condition: {{ .NamePrefix }}_psp_container and {{ .NamePrefix }}_psp_open_write
   output: >
     Pod Security Policy {{ .Name }} validation failure--write in container with readOnlyRootFilesystem=true
     (user=%user.name command=%proc.cmdline file=%fd.name parent=%proc.pname container_id=%container.id images=%container.image.repository)
@@ -213,25 +213,25 @@ var (
 #########################################
 # Rule(s) for PSP runAsUser property: MustRunAs + list of uids
 #########################################
-- rule: PSP Violation (runAsUser=MustRunAs) K8s Audit
+- rule: PSP {{ .NamePrefix }} Violation (runAsUser=MustRunAs) K8s Audit
   desc: >
     Detect a psp validation failure for a runAsUser outside of the allowed set using k8s audit logs
-  condition: psp_ka_container and not (ka.req.pod.containers.eff_run_as_user in ({{ JoinIDRanges .Spec.RunAsUser.Ranges }}))
+  condition: {{ .NamePrefix }}_psp_ka_container and not (ka.req.pod.containers.eff_run_as_user in ({{ JoinIDRanges .Spec.RunAsUser.Ranges }}))
   output: Pod Security Policy {{ .Name }} validation failure--runAsUser outside of allowed set. runAsUser set=({{ JoinIDRanges .Spec.RunAsUser.Ranges }}) (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace images=%ka.req.pod.containers.image spec=%jevt.value[/requestObject/spec]FOO=%ka.req.pod.containers.eff_run_as_user)
   priority: WARNING
   source: k8s_audit
   tags: [k8s-psp]
 
-- macro: psp_allowed_uids
+- macro: {{ .NamePrefix }}_psp_allowed_uids
   condition: >
    (
      {{ range $idx, $range := .Spec.RunAsUser.Ranges }} {{ if $idx}} or {{ end }}(user.uid >= {{ $range.Min }} and user.uid <= {{ $range.Max }}){{ end }}
    )
 
-- rule: PSP Violation (runAsUser=MustRunAs) System Activity
+- rule: PSP {{ .NamePrefix }} Violation (runAsUser=MustRunAs) System Activity
   desc: >
     Detect a psp validation failure for a runAsUser outside of the allowed set using syscalls
-  condition: psp_container and evt.type in (execve, setuid) and evt.dir=< and not psp_allowed_uids
+  condition: {{ .NamePrefix }}_psp_container and evt.type in (execve, setuid) and evt.dir=< and not {{ .NamePrefix }}_psp_allowed_uids
   output: Pod Security Policy {{ .Name }} validation failure--runAsUser outside of allowed set. runAsUser set=({{ JoinIDRanges .Spec.RunAsUser.Ranges }}) (command=%proc.cmdline uid=%user.uid container_id=%container.id images=%container.image.repository)
   priority: WARNING
   source: syscall
@@ -240,19 +240,19 @@ var (
 #########################################
 # Rule(s) for PSP runAsUser property: MustRunAsNonRoot
 #########################################
-- rule: PSP Violation (runAsUser=MustRunAsNonRoot) K8s Audit
+- rule: PSP {{ .NamePrefix }} Violation (runAsUser=MustRunAsNonRoot) K8s Audit
   desc: >
     Detect a psp validation failure for a uid=0 runAsUser when MustRunAsNonRoot is set using k8s audit logs
-  condition: psp_ka_container and (ka.req.pod.containers.eff_run_as_user intersects ("0:0"))
+  condition: {{ .NamePrefix }}_psp_ka_container and (ka.req.pod.containers.eff_run_as_user intersects ("0:0"))
   output: Pod Security Policy {{ .Name }} validation failure--uid 0 runAsUser when MustRunAsNonRoot is set (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace images=%ka.req.pod.containers.image spec=%jevt.value[/requestObject/spec])
   priority: WARNING
   source: k8s_audit
   tags: [k8s-psp]
 
-- rule: PSP Violation (runAsUser=MustRunAsNonRoot) System Activity
+- rule: PSP {{ .NamePrefix }} Violation (runAsUser=MustRunAsNonRoot) System Activity
   desc: >
     Detect a psp validation failure for a uid=0 user when MustRunAsNonRoot is set using syscalls
-  condition: psp_container and evt.type in (execve, setuid) and evt.dir=< and user.uid=0
+  condition: {{ .NamePrefix }}_psp_container and evt.type in (execve, setuid) and evt.dir=< and user.uid=0
   output: Pod Security Policy {{ .Name }} validation failure--root user when MustRunAsNonRoot is set (command=%proc.cmdline uid=%user.uid container_id=%container.id images=%container.image.repository)
   priority: WARNING
   source: syscall
@@ -261,25 +261,25 @@ var (
 #########################################
 # Rule(s) for PSP runAsGroup property: MustRunAs + list of gids
 #########################################
-- rule: PSP Violation (runAsGroup=MustRunAs) K8s Audit
+- rule: PSP {{ .NamePrefix }} Violation (runAsGroup=MustRunAs) K8s Audit
   desc: >
     Detect a psp validation failure for a runAsGroup outside of the MustRunAs allowed set using k8s audit logs
-  condition: psp_ka_container and not (ka.req.pod.containers.eff_run_as_group in ({{ JoinIDRanges .Spec.RunAsGroup.Ranges }}))
+  condition: {{ .NamePrefix }}_psp_ka_container and not (ka.req.pod.containers.eff_run_as_group in ({{ JoinIDRanges .Spec.RunAsGroup.Ranges }}))
   output: Pod Security Policy {{ .Name }} validation failure--runAsGroup outside of the MustRunAs allowed set. runAsGroup MustRunAs set=({{ JoinIDRanges .Spec.RunAsUser.Ranges }}) (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace images=%ka.req.pod.containers.image spec=%jevt.value[/requestObject/spec])
   priority: WARNING
   source: k8s_audit
   tags: [k8s-psp]
 
-- macro: psp_allowed_gids
+- macro: {{ .NamePrefix }}_psp_allowed_gids
   condition: >
    (
      {{ range $idx, $range := .Spec.RunAsGroup.Ranges }}{{ if $idx }} or {{ end }}(group.gid >= {{ $range.Min }} and group.gid <= {{ $range.Max }}){{ end }}
    )
 
-- rule: PSP Violation (runAsGroup=MustRunAs) System Activity
+- rule: PSP {{ .NamePrefix }} Violation (runAsGroup=MustRunAs) System Activity
   desc: >
     Detect a psp validation failure for a runAsGroup outside of the allowed set using syscalls
-  condition: psp_container and evt.type in (execve, setgid) and evt.dir=< and not psp_allowed_gids
+  condition: {{ .NamePrefix }}_psp_container and evt.type in (execve, setgid) and evt.dir=< and not {{ .NamePrefix }}_psp_allowed_gids
   output: Pod Security Policy {{ .Name }} validation failure--runAsGroup outside of allowed set. runAsGroup set=({{ JoinIDRanges .Spec.RunAsGroup.Ranges }}) (command=%proc.cmdline user=%user.uid gid=%group.gid container_id=%container.id images=%container.image.repository)
   priority: WARNING
   source: syscall
@@ -288,10 +288,10 @@ var (
 #########################################
 # Rule(s) for PSP runAsGroup property: MayRunAs + list of gids
 #########################################
-- rule: PSP Violation (runAsGroup=MayRunAs)
+- rule: PSP {{ .NamePrefix }} Violation (runAsGroup=MayRunAs)
   desc: >
     Detect a psp validation failure for a runAsGroup outside of the MayRunAs allowed set using k8s audit logs
-  condition: psp_ka_container and not ka.req.pod.containers.eff_run_as_group in ({{ JoinIDRanges .Spec.RunAsGroup.Ranges }}) and not (ka.req.pod.containers.run_as_group in ("<NA>") and ka.req.pod.run_as_group="<NA>")
+  condition: {{ .NamePrefix }}_psp_ka_container and not ka.req.pod.containers.eff_run_as_group in ({{ JoinIDRanges .Spec.RunAsGroup.Ranges }}) and not (ka.req.pod.containers.run_as_group in ("<NA>") and ka.req.pod.run_as_group="<NA>")
   output: Pod Security Policy {{ .Name }} validation failure--runAsGroup outside of the MayRunAs allowed set. runAsGroup MayRunAs set=({{ JoinIDRanges .Spec.RunAsGroup.Ranges }}) (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace images=%ka.req.pod.containers.image spec=%jevt.value[/requestObject/spec])
   priority: WARNING
   source: k8s_audit
@@ -300,10 +300,10 @@ var (
 #########################################
 # Rule(s) for PSP supplementalGroups property: MustRunAs + list of gids
 #########################################
-- rule: PSP Violation (supplementalGroups=MustRunAs)
+- rule: PSP {{ .NamePrefix }} Violation (supplementalGroups=MustRunAs)
   desc: >
     Detect a psp validation failure for supplementalGroups outside of the MustRunAs allowed set using k8s audit logs
-  condition: psp_ka_container and not ka.req.pod.supplemental_groups in ({{ JoinIDRanges .Spec.SupplementalGroups.Ranges }})
+  condition: {{ .NamePrefix }}_psp_ka_container and not ka.req.pod.supplemental_groups in ({{ JoinIDRanges .Spec.SupplementalGroups.Ranges }})
   output: Pod Security Policy {{ .Name }} validation failure--supplementalGroups outside of the MustRunAs allowed set. supplementalGroups MustRunAs set=({{ JoinIDRanges .Spec.SupplementalGroups.Ranges }}) (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace images=%ka.req.pod.containers.image spec=%jevt.value[/requestObject/spec])
   priority: WARNING
   source: k8s_audit
@@ -312,10 +312,10 @@ var (
 #########################################
 # Rule(s) for PSP supplementalGroups property: MayRunAs + list of gids
 #########################################
-- rule: PSP Violation (supplementalGroups=MayRunAs)
+- rule: PSP {{ .NamePrefix }} Violation (supplementalGroups=MayRunAs)
   desc: >
     Detect a psp validation failure for a supplementalGroups outside of the MayRunAs allowed set using k8s audit logs
-  condition: psp_ka_container and not ka.req.pod.supplemental_groups in ({{ JoinIDRanges .Spec.SupplementalGroups.Ranges }},"<NA>")
+  condition: {{ .NamePrefix }}_psp_ka_container and not ka.req.pod.supplemental_groups in ({{ JoinIDRanges .Spec.SupplementalGroups.Ranges }},"<NA>")
   output: Pod Security Policy {{ .Name }} validation failure--supplementalGroups outside of the MayRunAs allowed set. supplementalGroups MayRunAs set=({{ JoinIDRanges .Spec.SupplementalGroups.Ranges }}) (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace images=%ka.req.pod.containers.image spec=%jevt.value[/requestObject/spec])
   priority: WARNING
   source: k8s_audit
@@ -325,13 +325,13 @@ var (
 # Rule(s) for PSP allowPrivilegeEscalation property
 #########################################
 
-- macro: psp_allow_privilege_escalation
+- macro: {{ .NamePrefix }}_psp_allow_privilege_escalation
   condition: (ka.req.pod.containers.allow_privilege_escalation intersects (true))
 
-- rule: PSP Violation (allowPrivilegeEscalation)
+- rule: PSP {{ .NamePrefix }} Violation (allowPrivilegeEscalation)
   desc: >
     Detect a psp validation failure for allowPrivilegeEscalation using k8s audit logs
-  condition: psp_ka_container and psp_allow_privilege_escalation
+  condition: {{ .NamePrefix }}_psp_ka_container and {{ .NamePrefix }}_psp_allow_privilege_escalation
   output: Pod Security Policy {{ .Name }} validation failure--pod with allowPrivilegeEscalation=true (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace images=%ka.req.pod.containers.image spec=%jevt.value[/requestObject/spec])
   priority: WARNING
   source: k8s_audit
@@ -340,10 +340,10 @@ var (
 #########################################
 # Rule(s) for PSP allowedCapabilities property
 #########################################
-- rule: PSP Violation (allowedCapabilities)
+- rule: PSP {{ .NamePrefix }} Violation (allowedCapabilities)
   desc: >
     Detect a psp validation failure for Allowed Capabilities using k8s audit logs
-  condition: psp_ka_container and not ka.req.pod.containers.add_capabilities in ({{ JoinCapabilities .Spec.AllowedCapabilities }},"<NA>")
+  condition: {{ .NamePrefix }}_psp_ka_container and not ka.req.pod.containers.add_capabilities in ({{ JoinCapabilities .Spec.AllowedCapabilities }},"<NA>")
   output: Pod Security Policy {{ .Name }} validation failure--pod added capabilities outside of allowed set "({{ JoinCapabilities .Spec.AllowedCapabilities }})" (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace images=%ka.req.pod.containers.image spec=%jevt.value[/requestObject/spec])
   priority: WARNING
   source: k8s_audit
@@ -352,10 +352,10 @@ var (
 #########################################
 # Rule(s) for PSP allowedProcMountTypes property
 #########################################
-- rule: PSP Violation (allowedProcMountTypes)
+- rule: PSP {{ .NamePrefix }} Violation (allowedProcMountTypes)
   desc: >
     Detect a psp validation failure for Allowed Proc Mount Types using k8s audit logs
-  condition: psp_ka_container and not ka.req.pod.containers.proc_mount in ({{ JoinProcMountTypes .Spec.AllowedProcMountTypes }},"<NA>")
+  condition: {{ .NamePrefix }}_psp_ka_container and not ka.req.pod.containers.proc_mount in ({{ JoinProcMountTypes .Spec.AllowedProcMountTypes }},"<NA>")
   output: Pod Security Policy {{ .Name }} validation failure--pod with proc mounts outside of allowed set "({{ JoinProcMountTypes .Spec.AllowedProcMountTypes }})" (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace images=%ka.req.pod.containers.image spec=%jevt.value[/requestObject/spec])
   priority: WARNING
   source: k8s_audit


### PR DESCRIPTION
Add the ability to add a prefix to all generated lists, macros, and
rules. This makes it easier to load multiple rules files generated from
different PSPs without the generated rules/macros/lists overlapping with
each other.

The actual prefix to add is provided as a parameter to
NewConverter(). It can be a blank string, in which case the PSP name is
used as the prefix. If the name is missing for some reason, use the
string "psp".

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area library

> /area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
When generating rules from a PSP, add a unique prefix (default PSP Name) to all generated lists/macros/rules.
```
