### PR TITLE
Make the annotations for psp->rules optional

### DIFF
--- a/pkg/converter/psp/converter.go
+++ b/pkg/converter/psp/converter.go
@@ -45,6 +45,7 @@ type Converter struct {
 
 type PspTemplate struct {
 	NamePrefix string
+	PSPImages string
 	v1beta1.PodSecurityPolicy
 }
 
@@ -220,14 +221,14 @@ func (c *Converter) GenerateRules(pspString string) (string, error) {
 
 	c.debugLog("PSP Object: %v", pspTemplateArgs)
 
-	// The generated rules need a set of images for which
+	// The generated rules can have a set of images for which
 	// to scope the rules. A annotation with the key
 	// "falco-rules-psp-images" provides the list of images.
-	if _, ok := pspTemplateArgs.Annotations["falco-rules-psp-images"]; !ok {
-		return "", fmt.Errorf("PSP YAML document does not have an annotation \"falco-rules-psp-images\" that lists the images for which the generated rules should apply")
+	if _, ok := pspTemplateArgs.Annotations["falco-rules-psp-images"]; ok {
+		pspTemplateArgs.PSPImages = pspTemplateArgs.Annotations["falco-rules-psp-images"]
 	}
 
-	c.debugLog("Images %v", pspTemplateArgs.Annotations["falco-rules-psp-images"])
+	c.debugLog("Images %v", pspTemplateArgs.PSPImages)
 
 	var rulesB bytes.Buffer
 


### PR DESCRIPTION
In some cases, someone might want to generate a set of rules without any
restrictions on image. (For example, everything in a cluster, or in a
namespace, etc).

To help support this, make the annotation falco-rules-psp-images
optional. If not present, the generated rules will match all images.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area library

> /area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
Allow PSP->Rules conversion without any restriction on container image when the annotation falco-rules-psp-images is not present.
```
