### PR TITLE
build: releases using goreleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.idea*
 .idea/*
 falcoctl
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,30 @@
+project_name: falcoctl
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - id: "falcoctl"
+    goos:
+    - linux
+    - darwin
+    - windows
+    goarch:
+    - amd64
+    - 386
+    main: .
+    env:
+      - GO111MODULE=on
+      - CGO_ENABLED=0
+    binary: falcoctl
+archives:
+  - id: windows
+    format_overrides:
+      - goos: windows
+        format: zip
+
+snapshot:
+  name_template: 'master'
+
+release:
+  github:
+  prerelease: auto

--- a/release.md
+++ b/release.md
@@ -1,0 +1,28 @@
+# falcoctl Release Process
+
+Our release process is automated using [goreleaser](https://github.com/goreleaser/goreleaser).
+
+When we release we do the following process:
+
+1. We decide together (usually in the #falco channel in Sysdig's slack) what's the next version to tag
+2. A person with repository rights does the tag
+3. The same person runs goreleaser in their machine following the "Release commands" section below
+4. The tag is live on Github with the artifacts
+5. Travis builds the tag and push the related docker images
+
+## Release commands
+
+Tag the version
+
+```bash
+git tag -a v0.1.0-rc.0 -m "v0.1.0-rc.0"
+git push origin v0.1.0-rc.0
+```
+
+Run goreleaser, make sure to export your GitHub token first.
+
+```
+export GITHUB_TOKEN=<YOUR_GH_TOKEN>
+goreleaser --rm-dist
+```
+

--- a/release.md
+++ b/release.md
@@ -1,10 +1,10 @@
-# falcoctl Release Process
+# Release Process
 
 Our release process is automated using [goreleaser](https://github.com/goreleaser/goreleaser).
 
 When we release we do the following process:
 
-1. We decide together (usually in the #falco channel in Sysdig's slack) what's the next version to tag
+1. We decide together (usually in the #falco channel in [slack](https://sysdig.slack.com)) what's the next version to tag
 2. A person with repository rights does the tag
 3. The same person runs goreleaser in their machine following the "Release commands" section below
 4. The tag is live on Github with the artifacts


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <lo@linux.com>

**What type of PR is this?**

/kind documentation
/kind feature

**Any specific area of the project related to this PR?**
NONE

**What this PR does / why we need it**:

We want to have all the releases done in the same way.
Using goreleaser we can produce the same artifacts regardless who is the maintainer doing the release by minimizing the manual steps. This also adds documentation for the single manual step we have to do

In the future this manual step can be automated by a CI when this project will have one.

**Which issue(s) this PR fixes**:

Fixes #24 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
