### PR TITLE
Parse PSPs strictly, disallowing unknown fields

### DIFF
--- a/pkg/converter/psp/converter.go
+++ b/pkg/converter/psp/converter.go
@@ -199,9 +199,10 @@ func (c *Converter) GenerateRules(namePrefix string, pspString string) (string, 
 		return "", fmt.Errorf("Could not convert generic yaml document to json: %v", err)
 	}
 
-	err = json.Unmarshal(pspJSON, &pspTemplateArgs)
+	decoder := json.NewDecoder(bytes.NewReader(pspJSON))
+	decoder.DisallowUnknownFields()
 
-	if err != nil {
+	if err := decoder.Decode(&pspTemplateArgs); err != nil {
 		return "", fmt.Errorf("Could not unmarshal json document: %v", err)
 	}
 


### PR DESCRIPTION
The current PSP converter allows parsing PSPS that contain extra fields,
for example:

```
apiVersion: policy/v1beta1
kind: PodSecurityPolicy
metadata:
  creationTimestamp: null
  name: test_psp
  annotations:
    falco-rules-psp-images: "[nginx]"
not-a-real-field: nope
spec:
  privileged: false
  fsGroup:
    rule: RunAsAny
  runAsUser:
    rule: RunAsAny
  seLinux:
    rule: RunAsAny
  supplementalGroups:
    rule: RunAsAny
  volumes:
    - secret
```

Change this by using a json decoder with the DisallowUnknownFields() option.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

> /area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
When converting PSPs to rules, don't allow PSPs with unknown fields.
```
