### PR TITLE
fix(cmd): falco version is mandatory (and has no default) 

### DIFF
--- a/cmd/probe_install_linux.go
+++ b/cmd/probe_install_linux.go
@@ -39,6 +39,9 @@ type ProbeInstallOptions struct {
 
 // Validate validates the `install probe` command options
 func (o ProbeInstallOptions) Validate(c *cobra.Command, args []string) error {
+	if len(o.falcoVersion) == 0 {
+		return fmt.Errorf("missing Falco version: specify it via FALCOCTL_FALCO_VERSION env variable or via --falco-version flag")
+	}
 	return nil
 }
 
@@ -47,10 +50,7 @@ func NewProbeInstallOptions(streams genericclioptions.IOStreams) CommandOptions 
 	o := &ProbeInstallOptions{
 		IOStreams: streams,
 	}
-	o.falcoVersion = viper.GetString("falco-version") // FALCOCTL_FALCO_VERSION env var
-	if len(o.falcoVersion) == 0 {
-		o.falcoVersion = "0.17.1" // default
-	}
+	o.falcoVersion = viper.GetString("falco-version")      // FALCOCTL_FALCO_VERSION env var
 	o.falcoProbePath = viper.GetString("falco-probe-path") // FALCOCTL_FALCO_PROBE_PATH env var
 	if len(o.falcoProbePath) == 0 {
 		o.falcoProbePath = "/" // default
@@ -76,6 +76,9 @@ func NewProbeInstallCommand(streams genericclioptions.IOStreams) *cobra.Command 
 		DisableFlagsInUseLine: true,
 		Short:                 "Install the Falco probe locally",
 		Long:                  `Download and install the Falco module locally`,
+		PreRunE: func(cmd *cobra.Command, args []string) {
+			return o.Validate(cmd, args)
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			falcoProbeFullpath := path.Join(o.falcoProbePath, o.falcoProbeFile)
 			falcoConfigHash, err := probeloader.GetKernelConfigHash()


### PR DESCRIPTION


**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup



**Any specific area of the project related to this PR?**

/area cli

**What this PR does / why we need it**:

Forces the user to specify a Falco version for which to download the probe via the `install probe` command.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
fix: specifying Falco version when installing probe is mandatory now
```
