### PR TITLE
Add ability to limit generated rules to namespaces

### DIFF
--- a/cmd/psp_conv.go
+++ b/cmd/psp_conv.go
@@ -90,7 +90,7 @@ func convertPspFalcoRules(pspPath string, rulesPath string) error {
 		return fmt.Errorf("Could not create converter: %v", err)
 	}
 
-	rules, err := conv.GenerateRules("", string(psp))
+	rules, err := conv.GenerateRules("", string(psp), []string{})
 	if err != nil {
 		return fmt.Errorf("Could not convert psp file to falco rules: %v", err)
 	}

--- a/pkg/converter/psp/converter.go
+++ b/pkg/converter/psp/converter.go
@@ -45,6 +45,7 @@ type Converter struct {
 type PspTemplate struct {
 	NamePrefix string
 	PSPImages string
+	PSPNamespaces string
 	v1beta1.PodSecurityPolicy
 }
 
@@ -188,11 +189,11 @@ func NewConverter(debugLog LogFunc, infoLog LogFunc, errorLog LogFunc) (*Convert
 	}, nil
 }
 
-func (c *Converter) GenerateRules(namePrefix string, pspString string) (string, error) {
+func (c *Converter) GenerateRules(namePrefix string, pspString string, namespaces []string) (string, error) {
 
 	pspTemplateArgs := PspTemplate{}
 
-	c.debugLog("GenerateRules() namePrefix=%s, pspString=%s", pspString)
+	c.debugLog("GenerateRules() namePrefix=%s, pspString=%s, namespaces=%v", namePrefix, pspString, namespaces)
 
 	pspJSON, err := yaml.YAMLToJSON([]byte(pspString))
 	if err != nil {
@@ -230,6 +231,12 @@ func (c *Converter) GenerateRules(namePrefix string, pspString string) (string, 
 	// "falco-rules-psp-images" provides the list of images.
 	if _, ok := pspTemplateArgs.Annotations["falco-rules-psp-images"]; ok {
 		pspTemplateArgs.PSPImages = pspTemplateArgs.Annotations["falco-rules-psp-images"]
+	}
+
+	if _, ok := pspTemplateArgs.Annotations["falco-rules-psp-namespaces"]; ok {
+		pspTemplateArgs.PSPNamespaces = pspTemplateArgs.Annotations["falco-rules-psp-namespaces"]
+	} else if len(namespaces) > 0 {
+		pspTemplateArgs.PSPNamespaces = "[" + strings.Join(namespaces, ",") + "]"
 	}
 
 	c.debugLog("Images %v", pspTemplateArgs.PSPImages)

--- a/pkg/converter/psp/k8s_psp_rules_template.go
+++ b/pkg/converter/psp/k8s_psp_rules_template.go
@@ -24,6 +24,10 @@ var (
 - list: {{ .NamePrefix }}_psp_images
   items: {{ .PSPImages }}
 
+{{end}}{{ if ne .PSPNamespaces "" }}
+- list: {{ .NamePrefix }}_psp_namespaces
+  items: {{ .PSPNamespaces }}
+
 {{end}}# K8s audit specific macros here
 - macro: {{ .NamePrefix }}_psp_ka_always_true
   condition: (jevt.rawtime exists)
@@ -40,6 +44,14 @@ var (
 - macro: {{ .NamePrefix }}_psp_ka_pod
   condition: (ka.target.resource=pods and not ka.target.subresource exists)
 
+{{ if ne .PSPNamespaces "" }}
+- macro: {{ .NamePrefix}}_psp_match_namespace
+  condition: ka.target.namespace in ({{ .NamePrefix }}_psp_namespaces)
+{{else}}
+- macro: {{ .NamePrefix}}_psp_match_namespace
+  condition: {{ .NamePrefix }}_psp_ka_always_true
+{{end}}
+
 {{ if ne .PSPImages "" }}
 - macro: {{ .NamePrefix }}_psp_ka_match_image
   condition: (ka.req.pod.containers.image.repository in ({{ .NamePrefix }}_psp_images))
@@ -49,7 +61,7 @@ var (
 {{end}}
 
 - macro: {{ .NamePrefix }}_psp_ka_container
-  condition: ({{ .NamePrefix }}_psp_ka_enabled and {{ .NamePrefix }}_psp_kevt and {{ .NamePrefix }}_psp_ka_pod and ka.verb=create and {{ .NamePrefix }}_psp_ka_match_image)
+  condition: ({{ .NamePrefix }}_psp_ka_enabled and {{ .NamePrefix }}_psp_kevt and {{ .NamePrefix }}_psp_ka_pod and ka.verb=create and {{ .NamePrefix }}_psp_ka_match_image and {{ .NamePrefix}}_psp_match_namespace)
 
 # syscall audit specific macros here
 - macro: {{ .NamePrefix }}_psp_always_true


### PR DESCRIPTION
Add the ability to limit generated rules to specific namespaces (for k8s
audit events). If an annotation falco-rules-psp-namespaces is present on
the PSP, those namespaces are populated into a list _psp_namespaces and
used by a macro _psp_match_namespace.

You can also provide a slice of namespaces to the converter
GenerateRules method. This will be used if the psp has no annotation.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

 /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

> /area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
Add the ability to limit generated PSP rules to specific namespaces.
```
