### PR TITLE
Add cleanup for cr, crb and auditsink

### DIFF
--- a/pkg/kubernetes/falco.go
+++ b/pkg/kubernetes/falco.go
@@ -90,6 +90,24 @@ func (i *falcoInstaller) Delete() error {
 	} else {
 		logger.Always("Falco namespace deleted: %s", i.namespace)
 	}
+       err = i.rbacClient.ClusterRoles().Delete("falco-cluster-role", &metav1.DeleteOptions{})
+        if err != nil {
+                logger.Critical("Error deleting clusterrole: %v", err)
+        } else {
+                logger.Always("Falco clusterrole deleted: %s", "falco-cluster-role")
+        }
+        err = i.rbacClient.ClusterRoleBindings().Delete("falco-cluster-role-binding", &metav1.DeleteOptions{})
+        if err != nil {
+                logger.Critical("Error deleting clusterrolebinding: %v", "falco-cluster-role-binding")
+        } else {
+                logger.Always("Falco clusterrolebinding deleted: %s", "falco-cluster-role-binding")
+        }
+        err = i.auditClient.AuditSinks().Delete("falco-audit-sink", &metav1.DeleteOptions{})
+        if err != nil {
+                logger.Critical("Error deleting auditsink: %v", "falco-audit-sink")
+        } else {
+                logger.Always("Falco auditsink deleted: %s", "falco-audit-sink")
+        }
 	return nil
 }
 


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**Any specific area of the project related to this PR?**
/area cli

**What this PR does / why we need it**:
This PR adds cleanup functionality to cleanup non-namespaced falco objects (clusterrole, clusterrolebinding and auditsink). This is needed as these components are currently left behind after a delete.

**Which issue(s) this PR fixes**:
Fixes #48 

**Special notes for your reviewer**:
Not sure this is the _best_ way to do this as it has the object names hard-coded. However it does clean up the left behind objects which is missing at this point.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
