### PR TITLE
`install tls`: defaults, correct paths, gen client certs, fix server certs

### DIFF
--- a/cmd/install_tls_linux.go
+++ b/cmd/install_tls_linux.go
@@ -29,6 +29,7 @@ const (
 	DefaultCertsOrg     = "falcosecurity"
 	DefaultCertsName    = "localhost"
 	DefaultCertsPath    = "/etc/falco/certs"
+	DefaultCertsDays    = 365
 )
 
 // TLSInstallOptions represents the `install tls` command options
@@ -38,6 +39,7 @@ type TLSInstallOptions struct {
 	org     string
 	name    string
 	path    string
+	days    int
 }
 
 // Validate validates the `install probe` command options
@@ -68,6 +70,11 @@ func NewTLSInstallOptions(streams genericclioptions.IOStreams) CommandOptions {
 	if len(o.name) == 0 {
 		o.name = DefaultCertsName
 	}
+	// FALCOCTL_DAYS env var
+	o.path = viper.GetString("days")
+	if len(o.path) == 0 {
+		o.days = DefaultCertsDays
+	}
 	// FALCOCTL_PATH env var
 	o.path = viper.GetString("path")
 	if len(o.path) == 0 {
@@ -89,7 +96,7 @@ func NewTLSInstallCommand(streams genericclioptions.IOStreams) *cobra.Command {
 
 This command is a convenience to not only generate the TLS material, but also drop it off on the local filesystem.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			g := tls.NewGRPCTLSGenerator(o.country, o.org, o.name)
+			g := tls.NewGRPCTLSGenerator(o.country, o.org, o.name, o.days)
 			err := g.Generate()
 			if err != nil {
 				logger.Critical(err.Error())
@@ -108,6 +115,7 @@ This command is a convenience to not only generate the TLS material, but also dr
 	cmd.Flags().StringVarP(&o.country, "country", "c", o.country, "The country to self sign the TLS cert with")
 	cmd.Flags().StringVarP(&o.org, "org", "o", o.org, "The org to self sign the TLS cert with")
 	cmd.Flags().StringVarP(&o.name, "name", "n", o.name, "The name to self sign the TLS cert with")
+	cmd.Flags().IntVarP(&o.days, "days", "d", o.days, "The number of days to make self signed TLS cert valid for")
 	cmd.Flags().StringVarP(&o.path, "path", "p", o.path, "The path to write the TLS cert to")
 
 	return cmd

--- a/cmd/install_tls_linux.go
+++ b/cmd/install_tls_linux.go
@@ -27,7 +27,7 @@ import (
 const (
 	DefaultCertsCountry = "US"
 	DefaultCertsOrg     = "falcosecurity"
-	DefaultCertsName    = "Default"
+	DefaultCertsName    = "localhost"
 	DefaultCertsPath    = "/etc/falco/certs"
 )
 

--- a/pkg/tls/generator.go
+++ b/pkg/tls/generator.go
@@ -22,6 +22,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/kris-nova/logger"
 
@@ -50,6 +51,7 @@ type GRPCTLSGenerator struct {
 	Country       string
 	Organization  string
 	CommonName    string
+	Expiration    time.Duration
 	SubjectFields map[string]string
 	CACert        *openssl.Certificate
 	ServerCert    *openssl.Certificate
@@ -59,12 +61,13 @@ type GRPCTLSGenerator struct {
 }
 
 // NewGRPCTLSGenerator is used to init a new TLS Generator for Falco
-func NewGRPCTLSGenerator(country, organization, name string) *GRPCTLSGenerator {
+func NewGRPCTLSGenerator(country, organization, name string, days int) *GRPCTLSGenerator {
 	return &GRPCTLSGenerator{
 		RSABytes:      DefaultRSABytes,
 		Country:       country,
 		Organization:  organization,
 		CommonName:    name,
+		Expiration:    time.Duration(days) * 24 * time.Hour,
 		SubjectFields: DefaultX509SubjectFields,
 	}
 }
@@ -81,7 +84,7 @@ func (g *GRPCTLSGenerator) Generate() error {
 	certificateSigningInfo := &openssl.CertificateInfo{
 		Serial:       i64,
 		Issued:       0,
-		Expires:      0,
+		Expires:      g.Expiration,
 		Country:      g.Country,
 		Organization: g.Organization,
 		CommonName:   "Root CA",
@@ -117,7 +120,7 @@ func (g *GRPCTLSGenerator) Generate() error {
 	serverCertificateSigningInfo := &openssl.CertificateInfo{
 		Serial:       i64,
 		Issued:       0,
-		Expires:      0,
+		Expires:      g.Expiration,
 		Country:      g.Country,
 		Organization: g.Organization,
 		CommonName:   g.CommonName,
@@ -137,7 +140,7 @@ func (g *GRPCTLSGenerator) Generate() error {
 	serverCASigningInfo := &openssl.CertificateInfo{
 		Serial:       i64,
 		Issued:       0,
-		Expires:      0,
+		Expires:      g.Expiration,
 		Country:      g.Country,
 		Organization: g.Organization,
 		CommonName:   g.CommonName,

--- a/pkg/tls/generator.go
+++ b/pkg/tls/generator.go
@@ -137,14 +137,15 @@ func (g *GRPCTLSGenerator) Generate() error {
 		Organization: g.Organization,
 		CommonName:   g.CommonName,
 	}
-	serverCert, err := openssl.NewCertificate(serverCASigningInfo, caKey)
+	serverCert, err := openssl.NewCertificate(serverCASigningInfo, serverKey)
 	if err != nil {
 		return fmt.Errorf("unable to create new server cert: %v", err)
 	}
 	serverCert.SetIssuer(caCert)
-	err = caCert.Sign(caKey, openssl.EVP_SHA256)
+
+	err = serverCert.Sign(serverKey, openssl.EVP_SHA256)
 	if err != nil {
-		return fmt.Errorf("unable to sign caCert: %v", err)
+		return fmt.Errorf("unable to sign serverCert: %v", err)
 	}
 	err = serverCert.Sign(caKey, openssl.EVP_SHA256)
 	if err != nil {

--- a/pkg/tls/generator.go
+++ b/pkg/tls/generator.go
@@ -163,7 +163,6 @@ func (g *GRPCTLSGenerator) Generate() error {
 
 // FlushToDisk is used to persist the cert material from a GRPCTLSGenerator to disk given a path.
 func (g *GRPCTLSGenerator) FlushToDisk(path string) error {
-
 	p, err := satisfyDir(path)
 	if err != nil {
 		return fmt.Errorf("invalid path: %v", err)
@@ -236,11 +235,9 @@ func satisfyDir(dirName string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("unable to calculate absolute path: %v", err)
 	}
-	validDir := filepath.Dir(abs)
-	err = os.MkdirAll(validDir, 0644)
+	err = os.MkdirAll(abs, 0644)
 	if err == nil || os.IsExist(err) {
-		return validDir, nil
-	} else {
-		return "", fmt.Errorf("unable to ensure dir: %v", err)
+		return abs, nil
 	}
+	return "", fmt.Errorf("unable to ensure dir: %v", err)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind feature



**Any specific area of the project related to this PR?**



/area cli



**What this PR does / why we need it**:

This PR attempts to:
- fix the path in which the certs have to be written (at the moment it writes them in `/etc/falco` but the default path is `/etc/falco/certs`)
- fallbacks to environment variables for `install tls` flags (and uses defaults only in case there are not respective environment variables)

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #52 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
update(cmd): env variable fallbacks for install tls flags
fix(pkg/tls): put certs into /etc/falco/certs
fix(pkg/tls): correct server cert signing
```
