### PR TITLE
fix(cmd): typo in install tls command

### DIFF
--- a/cmd/install_tls.go
+++ b/cmd/install_tls.go
@@ -30,7 +30,7 @@ func NewTLSInstallCommand(streams genericclioptions.IOStreams) *cobra.Command {
 		Use:                   "tls",
 		DisableFlagsInUseLine: true,
 		Short:                 "Generate and install TLS material to be used with the Falco gRPC server",
-		Long:                  `Falco gRPC server runs with mutually encrypted TLS by default. 
+		Long:                  `Falco gRPC server runs with mutually encrypted TLS by default.
 
 This command is a convenience to not only generate the TLS material, but also drop it off on the local filesystem.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -42,4 +42,3 @@ This command is a convenience to not only generate the TLS material, but also dr
 
 	return cmd
 }
-package cmd


### PR DESCRIPTION
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind cleanup




**What this PR does / why we need it**:

Fixes a typo in the `install tls` command.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
