### PR TITLE
fix(cmd): correct undefined func calls

### DIFF
--- a/cmd/install_module_linux.go
+++ b/cmd/install_module_linux.go
@@ -85,12 +85,12 @@ func InstallModule(streams genericclioptions.IOStreams) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			falcoModuleFullpath := path.Join(o.falcoModulePath, o.falcoModuleFile)
-			falcoConfigHash, err := kernelmoduleloader.GetKernelConfigHash()
+			falcoConfigHash, err := kernelmoduleloader.KernelConfigHash()
 			if err != nil {
 				logger.Critical("Error getting Kernel Config Hash: %s", err)
 				return err
 			}
-			falcoKernelRelease, err := kernelmoduleloader.GetKernelRelease()
+			falcoKernelRelease, err := kernelmoduleloader.KernelRelease()
 			if err != nil {
 				logger.Critical("Error getting Kernel Version: %s", err)
 				return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:
Currently, `go build .` returns the following errors:
```
# github.com/falcosecurity/falcoctl/cmd
cmd/install_module_linux.go:88:28: undefined: kernelmoduleloader.GetKernelConfigHash
cmd/install_module_linux.go:93:31: undefined: kernelmoduleloader.GetKernelRelease
```
because of wrong function names. This PR just fixes this issue.

**Which issue(s) this PR fixes**:
#76 
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```