### PR TITLE
refactor(pkg/tls): simplified TLS implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,8 +20,7 @@ require (
 	github.com/mattn/go-isatty v0.0.10 // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
-	github.com/pkg/errors v0.8.1
-	github.com/spacemonkeygo/openssl v0.0.0-20181017203307-c2dcc5cca94a
+	github.com/pkg/errors v0.8.1 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -131,10 +131,6 @@ github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
-github.com/spacemonkeygo/openssl v0.0.0-20181017203307-c2dcc5cca94a h1:/eS3yfGjQKG+9kayBkj0ip1BGhq6zJ3eaVksphxAaek=
-github.com/spacemonkeygo/openssl v0.0.0-20181017203307-c2dcc5cca94a/go.mod h1:7AyxJNCJ7SBZ1MfVQCWD6Uqo2oubI2Eq2y2eqf+A5r0=
-github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 h1:RC6RW7j+1+HkWaX/Yh71Ee5ZHaHYt7ZP4sQgUrm6cDU=
-github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572/go.mod h1:w0SWMsp6j9O/dk4/ZpIhL+3CkG8ofA2vuv7k+ltqUMc=
 github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=

--- a/pkg/tls/generator.go
+++ b/pkg/tls/generator.go
@@ -17,6 +17,12 @@ limitations under the License.
 package tls
 
 import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
 	"io/ioutil"
 	"math/big"
@@ -25,206 +31,171 @@ import (
 	"time"
 
 	"github.com/kris-nova/logger"
-
-	"github.com/spacemonkeygo/openssl"
 )
 
+// DefaultRSABits is the default bit size to generate an RSA keypair
+const DefaultRSABits int = 4096
+
+// Certs material filenames
 const (
-	DefaultRSABytes   int = 4096
-	DefaultServerKey      = "server.key"
-	DefaultClientKey      = "client.key"
-	DefaultCAKey          = "ca.key"
-	DefaultServerCSR      = "server.csr"
-	DefaultClientCSR      = "client.csr"
-	DefaultCACert         = "ca.crt"
-	DefaultServerCert     = "server.crt"
-	DefaultClientCert     = "client.crt"
+	ServerKey  = "server.key"
+	ClientKey  = "client.key"
+	CAKey      = "ca.key"
+	CACert     = "ca.crt"
+	ServerCert = "server.crt"
+	ClientCert = "client.crt"
 )
 
-var (
-	DefaultX509SubjectFields = map[string]string{
-		"ST": "US",
-		"L":  "San Francisco",
-		"OU": "Default",
-	}
-)
+var certsFilenames = []string{
+	ServerKey,
+	ClientKey,
+	CAKey,
+	CACert,
+	ServerCert,
+	ClientCert,
+}
 
+// A GRPCTLS represents a TLS Generator for Falco
 type GRPCTLS struct {
-	RSABytes      int
-	Country       string
-	Organization  string
-	CommonName    string
-	Expiration    time.Duration
-	SubjectFields map[string]string
-	CACert        *openssl.Certificate
-	ServerCert    *openssl.Certificate
-	ServerCSR     *openssl.Certificate
-	ClientCert    *openssl.Certificate
-	ClientCSR     *openssl.Certificate
-	CAKey         openssl.PrivateKey
-	ServerKey     openssl.PrivateKey
-	ClientKey     openssl.PrivateKey
+	RSABits      int
+	Country      string
+	Organization string
+	CommonName   string
+	Expiration   time.Duration
+	certs        map[string]*bytes.Buffer
 }
 
 // GRPCTLSGenerator is used to init a new TLS Generator for Falco
 func GRPCTLSGenerator(country, organization, name string, days int) *GRPCTLS {
+	certs := make(map[string]*bytes.Buffer, len(certsFilenames))
 	return &GRPCTLS{
-		RSABytes:      DefaultRSABytes,
-		Country:       country,
-		Organization:  organization,
-		CommonName:    name,
-		Expiration:    time.Duration(days) * 24 * time.Hour,
-		SubjectFields: DefaultX509SubjectFields,
+		RSABits:      DefaultRSABits,
+		Country:      country,
+		Organization: organization,
+		CommonName:   name,
+		Expiration:   time.Duration(days) * 24 * time.Hour,
+		certs:        certs,
 	}
+}
+
+func (g *GRPCTLS) setKey(filename string, key *rsa.PrivateKey) error {
+	b, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return err
+	}
+	buf := new(bytes.Buffer)
+	if err := pem.Encode(buf, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: b}); err != nil {
+		return err
+	}
+	g.certs[filename] = buf
+	return nil
+}
+
+func (g *GRPCTLS) setCert(filename string, b []byte) error {
+	buf := new(bytes.Buffer)
+	if err := pem.Encode(buf, &pem.Block{Type: "CERTIFICATE", Bytes: b}); err != nil {
+		return err
+	}
+	g.certs[filename] = buf
+	return nil
 }
 
 // Generate is used to first generate TLS material in memory.
 func (g *GRPCTLS) Generate() error {
-	i64 := &big.Int{}
-	i64.SetInt64(01)
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	notBefore := time.Now()
+	notAfter := notBefore.Add(g.Expiration)
 
-	//$ openssl genrsa -passout pass:1234 -des3 -out ca.key 4096
-	caKey, err := openssl.GenerateRSAKey(g.RSABytes)
+	// CA
+	caKey, err := rsa.GenerateKey(rand.Reader, g.RSABits)
 	if err != nil {
-		return fmt.Errorf("unable to generate RSA key: %v", err)
+		return err
 	}
-	//$ openssl req -passin pass:1234 -new -x509 -days 365 -key ca.key -out ca.crt -subj  "/C=SP/ST=Italy/L=Ornavasso/O=Test/OU=Test/CN=Root CA"
-	certificateSigningInfo := &openssl.CertificateInfo{
-		Serial:       i64,
-		Issued:       0,
-		Expires:      g.Expiration,
-		Country:      g.Country,
-		Organization: g.Organization,
-		CommonName:   "Root CA",
-	}
-	caCert, err := openssl.NewCertificate(certificateSigningInfo, caKey)
+	g.setKey(CAKey, caKey)
+
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
-		return fmt.Errorf("unable to generate new signing certificate: %v", err)
+		return err
 	}
-	name := &openssl.Name{}
-	name.AddTextEntries(g.SubjectFields)
-	caCert.SetSubjectName(name)
-	caCert.SetVersion(openssl.X509_V3)
-	if err := caCert.AddExtensions(map[openssl.NID]string{
-		openssl.NID_basic_constraints:      "critical,CA:TRUE",
-		openssl.NID_key_usage:              "critical,keyCertSign,cRLSign",
-		openssl.NID_subject_key_identifier: "hash",
-		openssl.NID_netscape_cert_type:     "sslCA",
-	}); err != nil {
-		return fmt.Errorf("unable to add caCert extensions: %v", err)
-	}
-	err = caCert.Sign(caKey, openssl.EVP_SHA256)
-	if err != nil {
-		return fmt.Errorf("unable to sign caCert: %v", err)
+	caTemplate := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{g.Organization},
+			CommonName:   "Root CA",
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
 	}
 
-	//$ openssl genrsa -passout pass:1234 -des3 -out server.key 4096
-	serverKey, err := openssl.GenerateRSAKey(g.RSABytes)
+	b, err := x509.CreateCertificate(rand.Reader, &caTemplate, &caTemplate, &caKey.PublicKey, caKey)
 	if err != nil {
-		return fmt.Errorf("unable to generate server RSA key: %v", err)
+		return err
 	}
-	//$ openssl req -passin pass:1234 -new -key server.key -out server.csr -subj  "/C=SP/ST=Italy/L=Ornavasso/O=Test/OU=Server/CN=localhost"
-	serverCertificateSigningInfo := &openssl.CertificateInfo{
-		Serial:       i64,
-		Issued:       0,
-		Expires:      g.Expiration,
-		Country:      g.Country,
-		Organization: g.Organization,
-		CommonName:   g.CommonName,
-	}
-	serverCSR, err := openssl.NewCertificate(serverCertificateSigningInfo, serverKey)
+	g.setCert(CACert, b)
+
+	// Server
+	serverKey, err := rsa.GenerateKey(rand.Reader, g.RSABits)
 	if err != nil {
-		return fmt.Errorf("unable to generate new signing certificate: %v", err)
+		return err
 	}
-	serverName := &openssl.Name{}
-	serverName.AddTextEntries(g.SubjectFields)
-	serverCSR.SetSubjectName(serverName)
-	serverCSR.SetVersion(openssl.X509_V3)
-	err = serverCSR.Sign(serverKey, openssl.EVP_SHA256)
+	g.setKey(ServerKey, serverKey)
+
+	serialNumber, err = rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
-		return fmt.Errorf("unable to sign serverCSR: %v", err)
+		return err
 	}
-	serverCASigningInfo := &openssl.CertificateInfo{
-		Serial:       i64,
-		Issued:       0,
-		Expires:      g.Expiration,
-		Country:      g.Country,
-		Organization: g.Organization,
-		CommonName:   g.CommonName,
+	serverTemplate := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{g.Organization},
+			CommonName:   g.CommonName,
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  false,
 	}
-	//$ openssl x509 -req -passin pass:1234 -days 365 -in server.csr -CA ca.crt -CAkey ca.key -set_serial 01 -out server.crt
-	serverCert, err := openssl.NewCertificate(serverCASigningInfo, serverKey)
+	// todo(leogr) add support for IPAddresses
+	serverTemplate.DNSNames = append(serverTemplate.DNSNames, g.CommonName)
+
+	b, err = x509.CreateCertificate(rand.Reader, &serverTemplate, &caTemplate, &serverKey.PublicKey, caKey)
 	if err != nil {
-		return fmt.Errorf("unable to create new server cert: %v", err)
+		return nil
 	}
-	serverCert.SetIssuer(caCert)
-	err = serverCert.Sign(serverKey, openssl.EVP_SHA256)
+	g.setCert(ServerCert, b)
+
+	// Client
+	clientKey, err := rsa.GenerateKey(rand.Reader, g.RSABits)
 	if err != nil {
-		return fmt.Errorf("unable to sign serverCert: %v", err)
+		return err
 	}
-	err = serverCert.Sign(caKey, openssl.EVP_SHA256)
-	if err != nil {
-		return fmt.Errorf("unable to sign serverCert: %v", err)
+	g.setKey(ClientKey, clientKey)
+
+	clientTemplate := x509.Certificate{
+		SerialNumber: new(big.Int).SetInt64(4),
+		Subject: pkix.Name{
+			Organization: []string{g.Organization},
+			CommonName:   g.CommonName,
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  false,
 	}
 
-	//$ openssl genrsa -passout pass:1234 -des3 -out client.key 4096
-	clientKey, err := openssl.GenerateRSAKey(g.RSABytes)
+	b, err = x509.CreateCertificate(rand.Reader, &clientTemplate, &caTemplate, &clientKey.PublicKey, caKey)
 	if err != nil {
-		return fmt.Errorf("unable to generate client RSA key: %v", err)
+		return err
 	}
-	// $ openssl req -passin pass:1234 -new -key client.key -out client.csr -subj  "/C=SP/ST=Italy/L=Ornavasso/O=Test/OU=Client/CN=localhost"
-	clientCertificateSigningInfo := &openssl.CertificateInfo{
-		Serial:       i64,
-		Issued:       0,
-		Expires:      g.Expiration,
-		Country:      g.Country,
-		Organization: g.Organization,
-		CommonName:   g.CommonName,
-	}
-	clientCSR, err := openssl.NewCertificate(clientCertificateSigningInfo, clientKey)
-	if err != nil {
-		return fmt.Errorf("unable to generate new signing certificate: %v", err)
-	}
-	clientName := &openssl.Name{}
-	clientName.AddTextEntries(g.SubjectFields)
-	clientCSR.SetSubjectName(clientName)
-	clientCSR.SetVersion(openssl.X509_V3)
-	err = clientCSR.Sign(clientKey, openssl.EVP_SHA256)
-	if err != nil {
-		return fmt.Errorf("unable to sign clientCSR: %v", err)
-	}
-	clientCASigningInfo := &openssl.CertificateInfo{
-		Serial:       i64,
-		Issued:       0,
-		Expires:      g.Expiration,
-		Country:      g.Country,
-		Organization: g.Organization,
-		CommonName:   g.CommonName,
-	}
-	// $ openssl x509 -passin pass:1234 -req -days 365 -in client.csr -CA ca.crt -CAkey ca.key -set_serial 01 -out client.crt
-	clientCert, err := openssl.NewCertificate(clientCASigningInfo, clientKey)
-	if err != nil {
-		return fmt.Errorf("unable to create new client cert: %v", err)
-	}
-	clientCert.SetIssuer(caCert)
-	err = clientCert.Sign(clientKey, openssl.EVP_SHA256)
-	if err != nil {
-		return fmt.Errorf("unable to sign clientCert: %v", err)
-	}
-	err = clientCert.Sign(caKey, openssl.EVP_SHA256)
-	if err != nil {
-		return fmt.Errorf("unable to sign clientCert: %v", err)
-	}
-
-	// Cache TLS Cert material
-	g.CACert = caCert
-	g.ServerCert = serverCert
-	g.ServerCSR = serverCSR
-	g.ClientCert = clientCert
-	g.ClientCSR = clientCSR
-	g.CAKey = caKey
-	g.ServerKey = serverKey
-	g.ClientKey = clientKey
+	g.setCert(ClientCert, b)
 
 	return nil
 }
@@ -237,100 +208,12 @@ func (g *GRPCTLS) FlushToDisk(path string) error {
 	}
 	path = p
 
-	// --- Write server.crt
-	serverCert, err := g.ServerCert.MarshalPEM()
-	if err != nil {
-		return fmt.Errorf("unable to marshal PEM data for serverCRT: %v", err)
-	}
-	f := filepath.Join(path, DefaultServerCert)
-	logger.Always("Writing: %s", f)
-	err = ioutil.WriteFile(f, serverCert, 0600)
-	if err != nil {
-		return fmt.Errorf("error writing [%s]: %v", f, err)
-	}
-
-	// --- Write client.crt
-	clientCert, err := g.ClientCert.MarshalPEM()
-	if err != nil {
-		return fmt.Errorf("unable to marshal PEM data for serverCRT: %v", err)
-	}
-	f = filepath.Join(path, DefaultClientCert)
-	logger.Always("Writing: %s", f)
-	err = ioutil.WriteFile(f, clientCert, 0600)
-	if err != nil {
-		return fmt.Errorf("error writing [%s]: %v", f, err)
-	}
-
-	// --- Write ca.crt
-	caCert, err := g.CACert.MarshalPEM()
-	if err != nil {
-		return fmt.Errorf("unable to marshal PEM data for caCert: %v", err)
-	}
-	f = filepath.Join(path, DefaultCACert)
-	logger.Always("Writing: %s", f)
-	err = ioutil.WriteFile(f, caCert, 0600)
-	if err != nil {
-		return fmt.Errorf("error writing [%s]: %v", f, err)
-	}
-
-	// --- Write server.csr
-	serverCSR, err := g.ServerCSR.MarshalPEM()
-	if err != nil {
-		return fmt.Errorf("unable to marshal PEM data for serverCSR: %v", err)
-	}
-	f = filepath.Join(path, DefaultServerCSR)
-	logger.Always("Writing: %s", f)
-	err = ioutil.WriteFile(f, serverCSR, 0600)
-	if err != nil {
-		return fmt.Errorf("error writing [%s]: %v", f, err)
-	}
-
-	// --- Write client.csr
-	clientCSR, err := g.ClientCSR.MarshalPEM()
-	if err != nil {
-		return fmt.Errorf("unable to marshal PEM data for clientCSR: %v", err)
-	}
-	f = filepath.Join(path, DefaultClientCSR)
-	logger.Always("Writing: %s", f)
-	err = ioutil.WriteFile(f, clientCSR, 0600)
-	if err != nil {
-		return fmt.Errorf("error writing [%s]: %v", f, err)
-	}
-
-	// --- Write ca.key
-	caKey, err := g.CAKey.MarshalPKCS1PrivateKeyPEM()
-	if err != nil {
-		return fmt.Errorf("unable to marshal PEM data for caKey: %v", err)
-	}
-	f = filepath.Join(path, DefaultCAKey)
-	logger.Always("Writing: %s", f)
-	err = ioutil.WriteFile(f, caKey, 0600)
-	if err != nil {
-		return fmt.Errorf("error writing [%s]: %v", f, err)
-	}
-
-	// --- Write server.key
-	serverKey, err := g.ServerKey.MarshalPKCS1PrivateKeyPEM()
-	if err != nil {
-		return fmt.Errorf("unable to marshal PEM data for serverKey: %v", err)
-	}
-	f = filepath.Join(path, DefaultServerKey)
-	logger.Always("Writing: %s", f)
-	err = ioutil.WriteFile(f, serverKey, 0600)
-	if err != nil {
-		return fmt.Errorf("error writing [%s]: %v", f, err)
-	}
-
-	// --- Write client.key
-	clientKey, err := g.ClientKey.MarshalPKCS1PrivateKeyPEM()
-	if err != nil {
-		return fmt.Errorf("unable to marshal PEM data for clientKey: %v", err)
-	}
-	f = filepath.Join(path, DefaultClientKey)
-	logger.Always("Writing: %s", f)
-	err = ioutil.WriteFile(f, clientKey, 0600)
-	if err != nil {
-		return fmt.Errorf("error writing [%s]: %v", f, err)
+	for _, name := range certsFilenames {
+		f := filepath.Join(path, name)
+		logger.Always("Writing: %s", f)
+		if err := ioutil.WriteFile(f, g.certs[name].Bytes(), 0600); err != nil {
+			return fmt.Errorf(`unable to write "%s": %v`, name, err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Leonardo Grasso <me@leonardograsso.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area library

> /area cli

> /area tests

> /area examples

**What this PR does / why we need it**:
This PR simplifies and cleanups the TLS generator by removing the `github.com/spacemonkeygo/openssl` dependency. 
Furthermore, assuming we just need minimal implementation, this PR also improves several aspects:
- Remove unnecessary CSRs and Subjects fields
- Improve naming and comments

We needed this mainly because `github.com/spacemonkeygo/openssl` has not been updated since 2018 and broke the releasing process (see #56 ). 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #56 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
