### PR TITLE
cleanup(OWNERS): remove inactive approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,4 @@
 approvers:
-  - kris-nova
-  - markyjackson-taulia
-  - leodido
-  - fntlnz
-  - mstemm
   - leogr
 reviewers:
   - kris-nova
@@ -13,3 +8,9 @@ reviewers:
   - markyjackson-taulia
   - mstemm
   - leogr
+emeritus_approvers:
+  - kris-nova
+  - markyjackson-taulia
+  - leodido
+  - fntlnz
+  - mstemm


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind documentation

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

For https://github.com/falcosecurity/falco/issues/2115, this PR moves inactive approvers (who had very little or zero contributions over the past 6 months) from `approvers` to `emeritus_approvers` in OWNERS.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
