### PR TITLE
update(OWNERS): move inactive approvers to emeritus_approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,15 +1,10 @@
 approvers:
-  - kris-nova
-  - markyjackson-taulia
-  - leodido
-  - fntlnz
-  - mstemm
   - leogr
 reviewers:
-  - kris-nova
-  - fntlnz
-  - leodido
   - mfdii
+emeritus_approvers:
+  - kris-nova
   - markyjackson-taulia
+  - leodido
+  - fntlnz
   - mstemm
-  - leogr


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind documentation

**Any specific area of the project related to this PR?**

**What this PR does / why we need it:**

For https://github.com/falcosecurity/evolution/issues/157, this PR moves inactive approvers (who had very little or zero contributions over the past 6 months) from approvers to `emeritus_approvers` in OWNERS.

**Which issue(s) this PR fixes:**

**Special notes for your reviewer:**

Opened this in place of #111 , as following up the suggestion of https://github.com/falcosecurity/falcoctl/pull/111#issuecomment-1189153901.

```release-note
NONE
```