### PR TITLE
update(CI/build): build falcoctl binaries without using goreleaser

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -8,10 +8,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
-    outputs:
-      matrix: ${{ steps.configure.outputs.matrix }}
-      artifacts-dir: ${{ steps.configure.outputs.artifacts-dir }}
-      cache-key: ${{ steps.configure.outputs.cache-key }}
+    strategy:
+      matrix:
+        goos: [linux, darwin, windows]
+        goarch: [arm64, amd64]
+        exclude:
+          - goarch: arm64
+            goos: windows
     steps:
     - name: Checkout commit
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
@@ -23,52 +26,31 @@ jobs:
       with:
         go-version: 1.19
 
-    - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@68acf3b1adf004ac9c2f0a4259e85c5f66e99bef #v3.0.0
-      with:
-        distribution: goreleaser
-        version: v1.10.3
-        args: release --rm-dist --snapshot
+    - name: Build Falcoctl
+      run: >
+        go build -o falcoctl-${{ matrix.goos }}-${{ matrix.goarch }} .
+      env:
+        CGO_ENABLED: 0
+        GOOS: ${{ matrix.goos }}
+        GOARCH: ${{ matrix.goarch }}
 
-    - name: Save config variables
-      id: configure
+    - name: Create Archives
       run: |
-        # Save artifacts info in matrix variable. Only artifacts of type "Archive".
-        # The matrix variable is used in a later job to upload the artifacts.
-        matrix=$(jq 'map(. | select(.type=="Archive"))' dist/artifacts.json)
-        echo "::set-output name=matrix::{\"include\":$(echo $matrix)}"
-        
-        # Save the commit hash to be used as unique key for the cached artifacts.
-        echo "::set-output name=cache-key::${{ github.sha }}"
-        
-        # Save the artifacts directory in a variable.
-        echo "::set-output name=artifacts-dir::dist"
+        cp falcoctl-${{ matrix.goos }}-${{ matrix.goarch }} falcoctl
+        tar -czvf falcoctl-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz falcoctl LICENSE
 
-    - name: Cache artifacts - upload
-      id: cache-artifacts
-      uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 #v3.0.8
-      with:
-        path: ${{ steps.configure.outputs.artifacts-dir }}
-        key: ${{ steps.configure.outputs.cache-key }}
-
-  upload-artifacts:
-    runs-on: ubuntu-22.04
-    needs: build
-    strategy:
-      matrix: ${{ fromJson(needs.build.outputs.matrix) }}
-    steps:
-    - name: Cache artifacts - download
-      id: cache-artifacts
-      uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 #v3.0.8
-      with:
-        path: ${{ needs.build.outputs.artifacts-dir}}
-        key: ${{ needs.build.outputs.cache-key}}
-
-    - name: Upload ${{ matrix.name }}
+    - name: Upload falcoctl artifacts
       uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 #v3.1.0
       with:
-        name: ${{ matrix.name }}
-        path: ./${{ matrix.path }}
+        name: falcoctl-${{ matrix.goos }}-${{ matrix.goarch }}
+        path: ./falcoctl-${{ matrix.goos }}-${{ matrix.goarch }}
+        retention-days: 1
+
+    - name: Upload falcoctl archives
+      uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 #v3.1.0
+      with:
+        name: falcoctl-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz
+        path: ./falcoctl-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz
         retention-days: 1
 
   test:


### PR DESCRIPTION
Signed-off-by: Aldo Lacuku <aldo@lacuku.eu>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

> /area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

For each PR the CI builds the falcoctl binaries for multiple OS and architectures. The current workflow uses `goreleaser` and it takes up to 15 minutes to finish the build. The job runs on a single github runner and `goreleaser` by default uses all the available CPUs to parallelize the build process but unfortunately, the runners have only two cores. 

The new workflow uses the `matrixes` to build in parallel falcoctl. The matrix jobs can be allocated in multiple runners. That speeds the build time by 10x!

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
