### PR TITLE
update(cmd): check if registry is reachable before interacting with it

### DIFF
--- a/cmd/registry_login.go
+++ b/cmd/registry_login.go
@@ -17,14 +17,15 @@ package cmd
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
-	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 
+	"github.com/falcosecurity/falcoctl/cmd/internal/utils"
 	"github.com/falcosecurity/falcoctl/pkg/oci"
 	"github.com/falcosecurity/falcoctl/pkg/oci/authn"
 	"github.com/falcosecurity/falcoctl/pkg/options"
@@ -70,29 +71,27 @@ func NewLoginCmd(ctx context.Context, opt *options.CommonOptions) *cobra.Command
 
 // RunLogin executes the business logic for the login command.
 func (o *loginOptions) RunLogin(ctx context.Context, args []string) error {
+	var registry string
+
+	if n := len(args); n == 1 {
+		registry = args[0]
+	} else {
+		registry = oci.DefaultRegistry
+	}
+
 	user, token, err := getCredentials(o.Printer)
 	if err != nil {
 		return err
 	}
 
-	cred := auth.Credential{
+	cred := &auth.Credential{
 		Username: user,
 		Password: token,
 	}
 
-	client := authn.NewClient(cred)
-	if err != nil {
-		return err
-	}
-
-	// Ensure credentials are valid
-	registry, err := remote.NewRegistry(o.hostname)
-	if err != nil {
-		return err
-	}
-	registry.Client = client
-	if err = registry.Ping(ctx); err != nil {
-		return err
+	if err := utils.CheckRegistryConnection(ctx, cred, registry, o.Printer); err != nil {
+		o.Printer.Verbosef("%s", err.Error())
+		return fmt.Errorf("unable to connect to registry %q", registry)
 	}
 
 	// Store validated credentials
@@ -101,7 +100,7 @@ func (o *loginOptions) RunLogin(ctx context.Context, args []string) error {
 		return err
 	}
 
-	o.Printer.DefaultText.Println("Login succeeded")
+	o.Printer.Success.Println("Login succeeded")
 	return nil
 }
 

--- a/cmd/registry_pull.go
+++ b/cmd/registry_pull.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2"
@@ -104,6 +105,12 @@ func (o *pullOptions) RunPull(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	if err := utils.CheckRegistryConnection(ctx, &cred, registry, o.Printer); err != nil {
+		o.Printer.Verbosef("%s", err.Error())
+		return fmt.Errorf("unable to connect to registry %q", registry)
+	}
+
 	client := authn.NewClient(cred)
 
 	puller := ocipuller.NewPuller(client, newPullProgressTracker(o.Printer))

--- a/cmd/registry_push.go
+++ b/cmd/registry_push.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2"
@@ -106,6 +107,12 @@ func (o *pushOptions) RunPush(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	if err := utils.CheckRegistryConnection(ctx, &cred, registry, o.Printer); err != nil {
+		o.Printer.Verbosef("%s", err.Error())
+		return fmt.Errorf("unable to connect to registry %q", registry)
+	}
+
 	client := authn.NewClient(cred)
 
 	pusher := ocipusher.NewPusher(client, newPushProgressTracker(o.Printer))


### PR DESCRIPTION

Signed-off-by: Aldo Lacuku <aldo@lacuku.eu>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

This PR adds a common check for `login, push and pull` commands. It makes sure that the remote registry is reachable and that we have the required permissions to push and pull artifacts. In case of errors it prints an understandable error on why the command failed instead of printing the full stack error. The users can still have the full error by enabling the `verbose` mode using the `-v` flag.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
