### PR TITLE
fix: create an index with consistent state also when fetching it

### DIFF
--- a/cmd/index_add.go
+++ b/cmd/index_add.go
@@ -82,7 +82,7 @@ func (o *indexAddOptions) RunIndexAdd(ctx context.Context, args []string) error 
 		return nil
 	}
 
-	remoteIndex, err := index.FetchIndex(ctx, url)
+	remoteIndex, err := index.FetchIndex(ctx, url, name)
 	if err != nil {
 		return err
 	}

--- a/cmd/index_update.go
+++ b/cmd/index_update.go
@@ -83,7 +83,7 @@ func (o *indexUpdateOptions) RunIndexUpdate(ctx context.Context, args []string) 
 			return fmt.Errorf("cannot update index %s: not found", name)
 		}
 
-		remoteIndex, err := index.FetchIndex(ctx, indexConfigEntry.URL)
+		remoteIndex, err := index.FetchIndex(ctx, indexConfigEntry.URL, name)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: Lorenzo Susini <susinilorenzo1@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area library

> /area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

Correctly fill the entryByName map also when fetching an index remotely so that index normalization doesn't fail

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
