### PR TITLE
fix(cmd/utils): support connection checking for remote registries without authentication

### DIFF
--- a/cmd/internal/utils/validate.go
+++ b/cmd/internal/utils/validate.go
@@ -17,6 +17,8 @@ package utils
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"reflect"
 	"strings"
 
 	"oras.land/oras-go/v2/registry/remote"
@@ -37,9 +39,19 @@ func GetRegistryFromRef(ref string) (string, error) {
 }
 
 // CheckRegistryConnection checks whether the registry implement Docker Registry API V2 or
-// OCI Distribution Specification. It also checks authentication.
+// OCI Distribution Specification. It also checks authentication if credentials are not empty.
 func CheckRegistryConnection(ctx context.Context, cred *auth.Credential, regName string, printer *output.Printer) error {
 	sp, _ := printer.Spinner.Start(fmt.Sprintf("Checking connection to remote registry %q", regName))
+
+	if reflect.DeepEqual(*cred, auth.EmptyCredential) {
+		if err := checkRegistryUnauthenticated(ctx, regName); err != nil {
+			return err
+		}
+		sp.Success(fmt.Sprintf("Remote registry %q implements docker registry API V2", regName))
+		printer.Verbosef("Continuing without authentication, no user credentials provided")
+		return nil
+	}
+
 	client := authn.NewClient(*cred)
 
 	// Ensure credentials are valid.
@@ -53,7 +65,33 @@ func CheckRegistryConnection(ctx context.Context, cred *auth.Credential, regName
 		return err
 	}
 
-	sp.Success(fmt.Sprintf("Remote registry %q is reachable", regName))
+	sp.Success(fmt.Sprintf("Remote registry %q implements docker registry API V2", regName))
+	printer.Verbosef("Proceeding as user %q", cred.Username)
 
 	return nil
+}
+
+func checkRegistryUnauthenticated(ctx context.Context, regName string) error {
+	url := fmt.Sprintf("https://%s/v2/", regName)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return nil
+	case http.StatusUnauthorized:
+		// We are just checking if the V2 endpoint exists. Do not care about authorization/authentication.
+		return nil
+	default:
+		return fmt.Errorf("unable to check remote registry %q: %q", url, resp.Status)
+	}
 }


### PR DESCRIPTION

Signed-off-by: Aldo Lacuku <aldo@lacuku.eu>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

Before interacting with the remote registry we check that:
* the registry implements the right API i.e. Docker Registry API V2;
* and that we are authenticated;

But some commands such as the `falcoctl registry pull` should not check we are authenticated if no credentials are provided. When interacting with public repositories we do not need to be authenticated.

This PR fix the issue when no authentication is required by just skipping the related check when no credentials are not provided.

```bash
❯ ./falcoctl registry pull --type=plugin  ghcr.io/alacuku/myrules:latest --dest-dir=./destDir -v
 INFO  Preparing to pull artifact "ghcr.io/alacuku/myrules:latest" of type "plugin"
 INFO  Retrieving credentials from local store
 INFO  Remote registry "ghcr.io" implements docker registry API V2                                                                                                                                                                                                                                                                                                                                                                     
 INFO  Continuing without authentication, no user credentials provided
 ...
```
**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
