### PR TITLE
chore: rename `install tls` command to `tls install` to be compliant with new naming convention

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,7 +50,7 @@ func New(ctx context.Context) *cobra.Command {
 	opt.AddFlags(rootCmd.Flags())
 
 	// Commands
-	rootCmd.AddCommand(NewInstallCmd())
+	rootCmd.AddCommand(NewTLSCmd())
 	rootCmd.AddCommand(version.NewVersionCmd(opt))
 	rootCmd.AddCommand(NewRegistryCmd(ctx, opt))
 	rootCmd.AddCommand(NewIndexCmd(ctx, opt))

--- a/cmd/testdata/help.txt
+++ b/cmd/testdata/help.txt
@@ -8,8 +8,8 @@ Available Commands:
   completion  Generate the autocompletion script for the specified shell
   help        Help about any command
   index       Interact with index
-  install     Install a component with falcoctl
   registry    Interact with OCI registries
+  tls         Generate and install TLS material for Falco
   version     Print the falcoctl version information
 
 Flags:

--- a/cmd/testdata/noargsnoflags.txt
+++ b/cmd/testdata/noargsnoflags.txt
@@ -8,8 +8,8 @@ Available Commands:
   completion  Generate the autocompletion script for the specified shell
   help        Help about any command
   index       Interact with index
-  install     Install a component with falcoctl
   registry    Interact with OCI registries
+  tls         Generate and install TLS material for Falco
   version     Print the falcoctl version information
 
 Flags:

--- a/cmd/testdata/wrongflag.txt
+++ b/cmd/testdata/wrongflag.txt
@@ -7,8 +7,8 @@ Available Commands:
   completion  Generate the autocompletion script for the specified shell
   help        Help about any command
   index       Interact with index
-  install     Install a component with falcoctl
   registry    Interact with OCI registries
+  tls         Generate and install TLS material for Falco
   version     Print the falcoctl version information
 
 Flags:

--- a/cmd/tls.go
+++ b/cmd/tls.go
@@ -18,17 +18,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewInstall creates the `install` command
-func NewInstallCmd() *cobra.Command {
+// NewTLSCmd return the tls command.
+func NewTLSCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   "install",
+		Use:                   "tls",
 		TraverseChildren:      true,
 		DisableFlagsInUseLine: true,
-		Short:                 "Install a component with falcoctl",
-		Long:                  `Install a component with falcoctl`,
+		Short:                 "Generate and install TLS material for Falco",
+		Long:                  `Generate and install TLS material for Falco`,
 	}
 
-	cmd.AddCommand(NewInstallTLSCmd())
+	cmd.AddCommand(NewTLSInstallCmd())
 
 	return cmd
 }

--- a/cmd/tls_install.go
+++ b/cmd/tls_install.go
@@ -29,12 +29,12 @@ const (
 	defaultCertsDays    = 365
 )
 
-// NewInstallTLS creates the `install tls` command
-func NewInstallTLSCmd() *cobra.Command {
+// NewTLSInstallCmd returns the tls install command.
+func NewTLSInstallCmd() *cobra.Command {
 	options := tls.Options{}
 
 	cmd := &cobra.Command{
-		Use:                   "tls",
+		Use:                   "install",
 		DisableFlagsInUseLine: true,
 		Short:                 "Generate and install TLS material to be used with the Falco gRPC server",
 		Long: `Falco gRPC server runs with mutually encrypted TLS by default.


### PR DESCRIPTION
This allow to be compliant with the naming we have chosen for this repo and the other commands.

Signed-off-by: Lorenzo Susini <susinilorenzo1@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:
The naming convention for command is object and then verb, i.e `artifact install`.
To respect this, change `install tls` with `tls install`.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
