### PR TITLE
feature(cmd): add new global flag --disable-styling

### DIFF
--- a/cmd/artifact_install.go
+++ b/cmd/artifact_install.go
@@ -130,7 +130,7 @@ func (o *artifactInstallOptions) RunArtifactInstall(ctx context.Context, args []
 			destDir = o.rulesfilesDir
 		}
 
-		sp, _ := o.Printer.Spinner.Start(fmt.Sprintf("Extracting and installing %q %q", result.Type, result.Filename))
+		sp, _ := o.Printer.Spinner.Start(fmt.Sprintf("INFO: Extracting and installing %q %q", result.Type, result.Filename))
 		result.Filename = filepath.Join(tmpDir, result.Filename)
 
 		f, err := os.Open(result.Filename)

--- a/cmd/internal/utils/validate.go
+++ b/cmd/internal/utils/validate.go
@@ -107,7 +107,7 @@ func ParseReference(mergedIndexes *index.MergedIndexes, name string) (string, er
 // CheckRegistryConnection checks whether the registry implement Docker Registry API V2 or
 // OCI Distribution Specification. It also checks authentication if credentials are not empty.
 func CheckRegistryConnection(ctx context.Context, cred *auth.Credential, regName string, printer *output.Printer) error {
-	sp, _ := printer.Spinner.Start(fmt.Sprintf("Checking connection to remote registry %q", regName))
+	sp, _ := printer.Spinner.Start(fmt.Sprintf("INFO: Checking connection to remote registry %q", regName))
 
 	if reflect.DeepEqual(*cred, auth.EmptyCredential) {
 		if err := checkRegistryUnauthenticated(ctx, regName); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,7 +47,7 @@ func New(ctx context.Context) *cobra.Command {
 	}
 
 	// Global flags
-	opt.AddFlags(rootCmd.Flags())
+	opt.AddFlags(rootCmd.PersistentFlags())
 
 	// Commands
 	rootCmd.AddCommand(NewTLSCmd())

--- a/cmd/testdata/help.txt
+++ b/cmd/testdata/help.txt
@@ -13,7 +13,8 @@ Available Commands:
   version     Print the falcoctl version information
 
 Flags:
-  -h, --help      help for falcoctl
-  -v, --verbose   Enable verbose logs (default false)
+      --disable-styling   Disable output styling such as spinners, progress bars and colors. Styling is automatically disabled if not attacched to a tty (default false)
+  -h, --help              help for falcoctl
+  -v, --verbose           Enable verbose logs (default false)
 
 Use "falcoctl [command] --help" for more information about a command.

--- a/cmd/testdata/noargsnoflags.txt
+++ b/cmd/testdata/noargsnoflags.txt
@@ -13,7 +13,8 @@ Available Commands:
   version     Print the falcoctl version information
 
 Flags:
-  -h, --help      help for falcoctl
-  -v, --verbose   Enable verbose logs (default false)
+      --disable-styling   Disable output styling such as spinners, progress bars and colors. Styling is automatically disabled if not attacched to a tty (default false)
+  -h, --help              help for falcoctl
+  -v, --verbose           Enable verbose logs (default false)
 
 Use "falcoctl [command] --help" for more information about a command.

--- a/cmd/testdata/wrongflag.txt
+++ b/cmd/testdata/wrongflag.txt
@@ -12,8 +12,9 @@ Available Commands:
   version     Print the falcoctl version information
 
 Flags:
-  -h, --help      help for falcoctl
-  -v, --verbose   Enable verbose logs (default false)
+      --disable-styling   Disable output styling such as spinners, progress bars and colors. Styling is automatically disabled if not attacched to a tty (default false)
+  -h, --help              help for falcoctl
+  -v, --verbose           Enable verbose logs (default false)
 
 Use "falcoctl [command] --help" for more information about a command.
 

--- a/go.mod
+++ b/go.mod
@@ -131,9 +131,10 @@ require (
 	github.com/google/uuid v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/mattn/go-isatty v0.0.16
 	github.com/stretchr/testify v1.7.2 // indirect
 	golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2 // indirect
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect
-	golang.org/x/sys v0.0.0-20220804214406-8e32c043e418 // indirect
+	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab // indirect
 	golang.org/x/term v0.0.0-20220722155259-a9ba230a4035
 )

--- a/go.sum
+++ b/go.sum
@@ -387,6 +387,8 @@ github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
+github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
@@ -782,8 +784,8 @@ golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220804214406-8e32c043e418 h1:9vYwv7OjYaky/tlAeD7C4oC9EsPTlaFl1H2jS++V+ME=
-golang.org/x/sys v0.0.0-20220804214406-8e32c043e418/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab h1:2QkjZIsXupsJbJIdSjjUOgWK3aEtzyuh2mPt3l/CkeU=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/pkg/options/common_options.go
+++ b/pkg/options/common_options.go
@@ -35,6 +35,8 @@ type CommonOptions struct {
 	writer io.Writer
 	// Used to store the verbose flag, and then passed to the printer.
 	verbose bool
+	// Disable the styling if set to true.
+	disableStyling bool
 }
 
 // NewOptions returns a new CommonOptions struct.
@@ -67,10 +69,12 @@ func (o *CommonOptions) Initialize(cfgs ...Configs) {
 	}
 
 	// create the printer. The value of verbose is a flag value.
-	o.Printer = output.NewPrinter(o.printerScope, o.verbose, o.writer)
+	o.Printer = output.NewPrinter(o.printerScope, o.disableStyling, o.verbose, o.writer)
 }
 
 // AddFlags registers the common flags.
 func (o *CommonOptions) AddFlags(flags *pflag.FlagSet) {
 	flags.BoolVarP(&o.verbose, "verbose", "v", false, "Enable verbose logs (default false)")
+	flags.BoolVar(&o.disableStyling, "disable-styling", false, "Disable output styling such as spinners, progress bars and colors. "+
+		"Styling is automatically disabled if not attacched to a tty (default false)")
 }

--- a/pkg/output/output_test.go
+++ b/pkg/output/output_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Output", func() {
 	)
 
 	JustBeforeEach(func() {
-		printer = NewPrinter(scope, verbose, writer)
+		printer = NewPrinter(scope, false, verbose, writer)
 	})
 
 	JustAfterEach(func() {


### PR DESCRIPTION
Signed-off-by: Aldo Lacuku <aldo@lacuku.eu>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

This PR adds a ne global flag `--disable-styling` flag makes `falcoctl` tool output plain text by disabling spinners, progress bars, and colors. `falcoctl` can determine if it is not attached to a TTY and disable the styling. Furthermore, the user can forcibly disable the styling by using the --disable-styling flag.

Default output of `falcoctl`:
```bash
❯ ./falcoctl artifact install cloudtrail-rules --rulesfiles-dir=./
 INFO  Reading all configured index files from "/home/aldo/.config/falcoctl/indexes.yaml"
 INFO  Preparing to pull "ghcr.io/falcosecurity/plugins/ruleset/cloudtrail:latest"
 INFO  Remote registry "ghcr.io" implements docker registry API V2                                                                                                                                                                                                                                                                                                           
 INFO  Pulling 44136fa355b3: ############################################# 100% 
 INFO  Pulling e0dccb7b0f1d: ############################################# 100% 
 INFO  Pulling 575bced78731: ############################################# 100% 
 INFO  Artifact successfully installed in "./" 
```

Output when the styling is disabled:
```bash
❯ ./falcoctl artifact install cloudtrail-rules --rulesfiles-dir=./ --disable-styling
INFO: Reading all configured index files from "/home/aldo/.config/falcoctl/indexes.yaml"
INFO: Preparing to pull "ghcr.io/falcosecurity/plugins/ruleset/cloudtrail:latest"
INFO: Checking connection to remote registry "ghcr.io"                                                                                                                                                                                                                                                                                                                       
INFO: Remote registry "ghcr.io" implements docker registry API V2                                                                                                                                                                                                                                                                                                            
INFO: Pulling 44136fa355b3 
INFO: Pulling e0dccb7b0f1d 
INFO: Pulling 575bced78731 
INFO: Extracting and installing "rulesfile" "cloudtrail-rules-0.6.0.tar.gz"                                                                                                                                                                                                                                                                                                  
INFO: Artifact successfully installed in "./"  
```
**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
