### PR TITLE
refactor(cmd): remove duplicated code when creating pullers and pushers

### DIFF
--- a/cmd/internal/utils/registry.go
+++ b/cmd/internal/utils/registry.go
@@ -1,0 +1,68 @@
+// Copyright 2022 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	"oras.land/oras-go/v2/registry/remote/auth"
+
+	"github.com/falcosecurity/falcoctl/pkg/oci/authn"
+	ocipuller "github.com/falcosecurity/falcoctl/pkg/oci/puller"
+	ocipusher "github.com/falcosecurity/falcoctl/pkg/oci/pusher"
+	"github.com/falcosecurity/falcoctl/pkg/output"
+)
+
+// PullerForRegistry returns a new ocipuller.Puller ready to be used for the given registry.
+func PullerForRegistry(ctx context.Context, registry string, printer *output.Printer) (*ocipuller.Puller, error) {
+	client, err := ClientForRegistry(ctx, registry, printer)
+	if err != nil {
+		return nil, err
+	}
+
+	return ocipuller.NewPuller(client, output.NewTracker(printer, "Pulling")), nil
+}
+
+// PusherForRegistry returns ane ocipusher.Pusher ready to be used for the given registry.
+func PusherForRegistry(ctx context.Context, plainHTTP bool, registry string, printer *output.Printer) (*ocipusher.Pusher, error) {
+	client, err := ClientForRegistry(ctx, registry, printer)
+	if err != nil {
+		return nil, err
+	}
+	return ocipusher.NewPusher(client, plainHTTP, output.NewTracker(printer, "Pushing")), nil
+}
+
+// ClientForRegistry returns a new auth.Client for the given registry.
+// It authenticates the client if credentials are found in the system.
+func ClientForRegistry(ctx context.Context, registry string, printer *output.Printer) (*auth.Client, error) {
+	credentialStore, err := authn.NewStore([]string{}...)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create new store: %w", err)
+	}
+
+	printer.Verbosef("Retrieving credentials from local store")
+	cred, err := credentialStore.Credential(ctx, registry)
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve credentials for registry %s: %w", registry, err)
+	}
+
+	if err := CheckRegistryConnection(ctx, &cred, registry, printer); err != nil {
+		printer.Verbosef("%s", err.Error())
+		return nil, fmt.Errorf("unable to connect to registry %q", registry)
+	}
+
+	return authn.NewClient(cred), err
+}

--- a/pkg/oci/puller/puller.go
+++ b/pkg/oci/puller/puller.go
@@ -27,20 +27,18 @@ import (
 	"oras.land/oras-go/v2/registry/remote/auth"
 
 	"github.com/falcosecurity/falcoctl/pkg/oci"
+	"github.com/falcosecurity/falcoctl/pkg/output"
 )
-
-// ProgressTracker type of the tracker that the puller accepts. It implements the tracker logic.
-type ProgressTracker func(target oras.Target) oras.Target
 
 // Puller implements pull operations.
 type Puller struct {
 	Client  *auth.Client
-	tracker ProgressTracker
+	tracker output.Tracker
 }
 
 // NewPuller create a new puller that can be used for pull operations.
 // The client must be ready to be used by the puller.
-func NewPuller(client *auth.Client, tracker ProgressTracker) *Puller {
+func NewPuller(client *auth.Client, tracker output.Tracker) *Puller {
 	return &Puller{
 		Client:  client,
 		tracker: tracker,

--- a/pkg/oci/pusher/pusher.go
+++ b/pkg/oci/pusher/pusher.go
@@ -32,6 +32,7 @@ import (
 	"oras.land/oras-go/v2/registry/remote/auth"
 
 	"github.com/falcosecurity/falcoctl/pkg/oci"
+	"github.com/falcosecurity/falcoctl/pkg/output"
 )
 
 const (
@@ -52,18 +53,15 @@ var (
 	ErrInvalidDependenciesFormat = errors.New("invalid dependency format")
 )
 
-// ProgressTracker type of the tracker that the pusher accepts. It implements the tracker logic.
-type ProgressTracker func(target oras.Target) oras.Target
-
 // Pusher implements push operations.
 type Pusher struct {
 	Client    *auth.Client
-	tracker   ProgressTracker
+	tracker   output.Tracker
 	plainHTTP bool
 }
 
 // NewPusher create a new pusher that can be used for push operations.
-func NewPusher(client *auth.Client, plainHTTP bool, tracker ProgressTracker) *Pusher {
+func NewPusher(client *auth.Client, plainHTTP bool, tracker output.Tracker) *Pusher {
 	return &Pusher{
 		Client:    client,
 		tracker:   tracker,

--- a/pkg/oci/pusher/pusher_test.go
+++ b/pkg/oci/pusher/pusher_test.go
@@ -28,12 +28,13 @@ import (
 	"github.com/falcosecurity/falcoctl/pkg/oci"
 	"github.com/falcosecurity/falcoctl/pkg/oci/authn"
 	ocipusher "github.com/falcosecurity/falcoctl/pkg/oci/pusher"
+	"github.com/falcosecurity/falcoctl/pkg/output"
 )
 
 var _ = Describe("Pusher", func() {
 	var (
 		pusher                *ocipusher.Pusher
-		tracker               ocipusher.ProgressTracker
+		tracker               output.Tracker
 		ref                   string
 		filePathsAndPlatforms ocipusher.Option
 		filePaths             ocipusher.Option

--- a/pkg/output/tracker.go
+++ b/pkg/output/tracker.go
@@ -24,6 +24,16 @@ import (
 	"oras.land/oras-go/v2"
 )
 
+// Tracker get an oras.Target and returns a new target that implements the tracker logic.
+type Tracker func(target oras.Target) oras.Target
+
+// NewTracker returns a new Tracker.
+func NewTracker(printer *Printer, msg string) Tracker {
+	return func(target oras.Target) oras.Target {
+		return NewProgressTracker(printer, target, msg)
+	}
+}
+
 // ProgressTracker tracks the progress of pull and push operations.
 type ProgressTracker struct {
 	oras.Target


### PR DESCRIPTION
Signed-off-by: Aldo Lacuku <aldo@lacuku.eu>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

This PR adds some util functions to create the pusher, puller, and client for a given registry. By doing so we remove duplicated code across the commands that need to create a pusher or puller.
Furthermore, all the progress tracker used by the pusher and puller now lives under the `output` package.

**Which issue(s) this PR fixes**:
This refactor is needed for the upcoming new commands other than cleaning up our code base.
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
