### PR TITLE
chore(artifact/install): move default paths for plugins and rulesfiles to internal/config package

### DIFF
--- a/internal/artifact/install/install.go
+++ b/internal/artifact/install/install.go
@@ -30,11 +30,6 @@ import (
 	"github.com/falcosecurity/falcoctl/pkg/options"
 )
 
-const (
-	defaultPluginsDir    = "/usr/share/falco/plugins"
-	defaultRulesfilesDir = "/etc/falco"
-)
-
 type artifactInstallOptions struct {
 	*options.CommonOptions
 	rulesfilesDir string
@@ -58,9 +53,9 @@ func NewArtifactInstallCmd(ctx context.Context, opt *options.CommonOptions) *cob
 		},
 	}
 
-	cmd.Flags().StringVarP(&o.rulesfilesDir, "rulesfiles-dir", "", defaultRulesfilesDir,
+	cmd.Flags().StringVarP(&o.rulesfilesDir, "rulesfiles-dir", "", config.RulesfilesDir,
 		"directory where to install rules. Defaults to /etc/falco")
-	cmd.Flags().StringVarP(&o.pluginsDir, "plugins-dir", "", defaultPluginsDir,
+	cmd.Flags().StringVarP(&o.pluginsDir, "plugins-dir", "", config.PluginsDir,
 		"directory where to install plugins. Defaults to /usr/share/falco/plugins")
 
 	return cmd

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,13 @@ var (
 	IndexesFile string
 )
 
+const (
+	// PluginsDir default path where plugins are installed.
+	PluginsDir = "/usr/share/falco/plugins"
+	// RulesfilesDir default path where rulesfiles are installed.
+	RulesfilesDir = "/etc/falco"
+)
+
 func init() {
 	ConfigDir = filepath.Join(homedir.Get(), ".config")
 	FalcoctlPath = filepath.Join(ConfigDir, "falcoctl")


### PR DESCRIPTION
…s to internal/config package

Signed-off-by: Aldo Lacuku <aldo@lacuku.eu>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

Move default installation paths for `plugins` and `rulesfiles` to `internal/config` package

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
