### PR TITLE
update(internal/utils): return full path of the extracted files in ExtractTarGz func

### DIFF
--- a/internal/artifact/install/install.go
+++ b/internal/artifact/install/install.go
@@ -127,7 +127,7 @@ func (o *artifactInstallOptions) RunArtifactInstall(ctx context.Context, args []
 		}
 
 		// Extract artifact and move it to its destination directory
-		err = utils.ExtractTarGz(f, destDir)
+		_, err = utils.ExtractTarGz(f, destDir)
 		if err != nil {
 			return fmt.Errorf("cannot extract %q to %q: %w", result.Filename, destDir, err)
 		}


### PR DESCRIPTION

Signed-off-by: Aldo Lacuku <aldo@lacuku.eu>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area library

> /area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

Return full path of the extracted files in ExtractTarGz func. Having the path of the extracted files simplifies subsequent operations like moving around the files if we extract them in a temporary dir.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
