### PR TITLE
update(output/tracker): return a nil tracker if the printer is nil

### DIFF
--- a/pkg/output/tracker.go
+++ b/pkg/output/tracker.go
@@ -29,6 +29,10 @@ type Tracker func(target oras.Target) oras.Target
 
 // NewTracker returns a new Tracker.
 func NewTracker(printer *Printer, msg string) Tracker {
+	if printer == nil {
+		return nil
+	}
+
 	return func(target oras.Target) oras.Target {
 		return NewProgressTracker(printer, target, msg)
 	}
@@ -58,7 +62,7 @@ func (t *ProgressTracker) Push(ctx context.Context, expected v1.Descriptor, cont
 	if !t.Printer.DisableStyling {
 		progressBar, _ = t.ProgressBar.WithTotal(int(expected.Size)).WithTitle(fmt.Sprintf(" INFO  %s %s:", t.msg, d)).WithShowCount(false).Start()
 	} else {
-		fmt.Printf("INFO: %s %s \n", t.msg, d)
+		t.Info.Printfln("%s %s", t.msg, d)
 	}
 
 	reader := &trackedReader{


### PR DESCRIPTION
Signed-off-by: Aldo Lacuku <aldo@lacuku.eu>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area library

> /area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

This allows initialization of a `puller/pusher` without a tracker by passing a nil printer using the `NewTracker` function without explicitly setting the Tracker to nil.

Furthermore, uniforms the output messages by using the printer interface.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
