### PR TITLE
feat(artifact/follow): add new command "artifact follow"

### DIFF
--- a/cmd/artifact.go
+++ b/cmd/artifact.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/falcosecurity/falcoctl/internal/artifact/follow"
 	"github.com/falcosecurity/falcoctl/internal/artifact/info"
 	"github.com/falcosecurity/falcoctl/internal/artifact/install"
 	"github.com/falcosecurity/falcoctl/internal/artifact/search"
@@ -37,6 +38,7 @@ func NewArtifactCmd(ctx context.Context, opt *commonoptions.CommonOptions) *cobr
 	cmd.AddCommand(search.NewArtifactSearchCmd(ctx, opt))
 	cmd.AddCommand(install.NewArtifactInstallCmd(ctx, opt))
 	cmd.AddCommand(info.NewArtifactInfoCmd(ctx, opt))
+	cmd.AddCommand(follow.NewArtifactFollowCmd(ctx, opt))
 
 	return cmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"os/signal"
 	"syscall"
 
@@ -61,6 +62,7 @@ func Execute() {
 	// If the ctx is marked as done then we reset the signals.
 	go func() {
 		<-ctx.Done()
+		fmt.Printf("\nreceived signal, terminating...\n")
 		stop()
 	}()
 

--- a/internal/artifact/follow/doc.go
+++ b/internal/artifact/follow/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2022 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package follow defines the business logic to follow artifacts. Periodically checks if there are updates
+// and downlods them if any.
+package follow

--- a/internal/artifact/follow/follow.go
+++ b/internal/artifact/follow/follow.go
@@ -1,0 +1,170 @@
+// Copyright 2022 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package follow
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/falcosecurity/falcoctl/internal/config"
+	"github.com/falcosecurity/falcoctl/internal/follower"
+	"github.com/falcosecurity/falcoctl/internal/utils"
+	"github.com/falcosecurity/falcoctl/pkg/index"
+	"github.com/falcosecurity/falcoctl/pkg/options"
+)
+
+const timeout = time.Second * 5
+
+var longFollow = `Follow a list of artifacts from remote registry. It periodically
+checks if the artifacts changed and downloads the latest version based on the configured
+tags.
+
+Artifacts are passed as arguments. By just providing the name of the artifact the
+command will search for the artifact in the configured index files (see index command).
+If found it will use the 'registry' and 'repository' as specifiend in the index file.
+
+Example - Install and follow "cloudtrail" plugin using the "latest" (default) tag using the info found in the index file:
+	falcoctl artifact follow cloudtrail
+
+Example - Install and follow "cloudtrail:0.6.0" plugin using the "0.6.0" tag. Here we explicitly set the tag:
+	falcoctl artifact follow cloudtrail:0.6.0
+
+Example - Install and follow "cloudtrail" plugin and "cloutrail-rules" using the "latest" (default) tag:
+	falcoctl artifact follow cloudtrail cloudtrail-rules
+
+
+The command also supports the references for the artifacts composed by "registry" + "repository" + "tag":
+
+Example - Install and follow "cloudtrail" plugins using the full artifact reference:
+	falcoctl artifact follow ghcr.io/falcosecurity/plugins/ruleset/cloudtrail:0.6.0-rc1
+`
+
+type artifactFollowOptions struct {
+	*options.CommonOptions
+	rulesfilesDir string
+	pluginsDir    string
+	every         time.Duration
+	closeChan     chan bool
+}
+
+// NewArtifactFollowCmd returns the artifact follow command.
+func NewArtifactFollowCmd(ctx context.Context, opt *options.CommonOptions) *cobra.Command {
+	o := artifactFollowOptions{
+		CommonOptions: opt,
+		closeChan:     make(chan bool),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "follow [ref1 [ref2 ...]] [flags]",
+		Short: "Install a list of artifacts and continuously checks if there are updates",
+		Long:  longFollow,
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			o.Printer.CheckErr(o.RunArtifactFollow(ctx, args))
+		},
+	}
+
+	cmd.Flags().DurationVarP(&o.every, "every", "e", config.FollowResync, "Time interval how often it checks for a new version of the "+
+		"artifact")
+	// TODO (alacuku): move it in a dedicate data structure since they are in common with artifactInstall command.
+	cmd.Flags().StringVarP(&o.rulesfilesDir, "rulesfiles-dir", "", config.RulesfilesDir,
+		"Directory where to install rules")
+	cmd.Flags().StringVarP(&o.pluginsDir, "plugins-dir", "", config.PluginsDir,
+		"Directory where to install plugins")
+
+	return cmd
+}
+
+// RunArtifactFollow executes the business logic for the artifact follow command.
+func (o *artifactFollowOptions) RunArtifactFollow(ctx context.Context, args []string) error {
+	o.Printer.Info.Printfln("Reading all configured index files from %q", config.IndexesFile)
+	indexConfig, err := index.NewConfig(config.IndexesFile)
+	if err != nil {
+		return err
+	}
+
+	mergedIndexes, err := utils.Indexes(indexConfig, config.FalcoctlPath)
+	if err != nil {
+		return err
+	}
+
+	if len(mergedIndexes.Entries) < 1 {
+		o.Printer.Warning.Println("No configured index. Consider to configure one using the 'index add' command.")
+	}
+
+	var wg sync.WaitGroup
+	// Disable styling
+	o.Printer.DisableStylingf()
+	// For each artifact create a follower.
+	var followers = make(map[string]*follower.Follower, 0)
+	for _, a := range args {
+		o.Printer.Info.Printfln("Creating follower for %q", a)
+		ref, err := utils.ParseReference(mergedIndexes, a)
+		if err != nil {
+			return fmt.Errorf("unable to parse artifact reference for %q: %w", a, err)
+		}
+
+		cfg := &follower.Config{
+			WaitGroup:         &wg,
+			Resync:            o.every,
+			RulefilesDir:      o.rulesfilesDir,
+			PluginsDir:        o.pluginsDir,
+			ArtifactReference: ref,
+			Verbose:           o.IsVerbose(),
+			CloseChan:         o.closeChan,
+		}
+		fol, err := follower.New(ctx, ref, o.Printer, cfg)
+		if err != nil {
+			return fmt.Errorf("unable to create the follower for ref %q: %w", ref, err)
+		}
+		wg.Add(1)
+		followers[ref] = fol
+	}
+	// Enable styling
+	o.Printer.EnableStyling()
+
+	for k, f := range followers {
+		o.Printer.Info.Printfln("Starting follower for %q", k)
+		go f.Follow(ctx)
+	}
+
+	// Wait until we receive a signal to be terminated
+	<-ctx.Done()
+
+	// We are done, shutdown the followers.
+	o.Printer.DefaultText.Printfln("closing followers...")
+	close(o.closeChan)
+
+	// Wait for the followers to shutdown or that the timer expires.
+	doneChan := make(chan bool)
+
+	go func() {
+		wg.Wait()
+		close(doneChan)
+	}()
+
+	select {
+	case <-doneChan:
+		o.Printer.DefaultText.Printfln("followers correctly stopped.")
+	case <-time.After(timeout):
+		o.Printer.DefaultText.Printfln("Timed out waiting for followers to exit")
+	}
+
+	return nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"path/filepath"
+	"time"
 
 	"github.com/docker/docker/pkg/homedir"
 )
@@ -34,6 +35,9 @@ const (
 	PluginsDir = "/usr/share/falco/plugins"
 	// RulesfilesDir default path where rulesfiles are installed.
 	RulesfilesDir = "/etc/falco"
+	// FollowResync time interval how often it checks for newer version of the artifact.
+	// Default values is set every 24 hours.
+	FollowResync = time.Hour * 24
 )
 
 func init() {

--- a/internal/follower/doc.go
+++ b/internal/follower/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2022 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package follower defines the Follower type. It is used to track a specific artifact version denoted by its tag.
+// Periodically it checks if a new version has been pushed and if so pulls and installs it in a given directory.
+// Each Follower can track only one artifact, if you need to track multiple artiacts then instantiate a follower for each one.
+package follower

--- a/internal/follower/follower.go
+++ b/internal/follower/follower.go
@@ -1,0 +1,298 @@
+// Copyright 2022 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package follower
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/falcosecurity/falcoctl/internal/utils"
+	"github.com/falcosecurity/falcoctl/pkg/oci"
+	ocipuller "github.com/falcosecurity/falcoctl/pkg/oci/puller"
+	"github.com/falcosecurity/falcoctl/pkg/output"
+)
+
+// Follower knows how to track an artifact in a remote repository given the reference.
+// It starts a new goroutine to check for updates periodically. If an update is available
+// it pulls the new version and installs it in the correct directory.
+type Follower struct {
+	ref           string
+	tag           string
+	workingDir    string
+	currentDigest string
+	*ocipuller.Puller
+	*Config
+	*output.Printer
+}
+
+// Config configuration options for the Follower.
+type Config struct {
+	WaitGroup *sync.WaitGroup
+	// CloseChan used to close the follower.
+	CloseChan <-chan bool
+	// Resync time after which periodically it checks for new a new version.
+	Resync time.Duration
+	// RulesfileDir directory where the rulesfile are stored.
+	RulefilesDir string
+	// PluginsDir directory where the plugins are stored.
+	PluginsDir string
+	// ArtifactReference reference to the artifact in a remote repository.
+	ArtifactReference string
+	// Verbose enables the verbose logs.
+	Verbose bool
+}
+
+// New creates a Follower configured with the passed parameters and ready to be used.
+// It does not check the correctness of the parameters, make sure everything is initialized.
+func New(ctx context.Context, ref string, printer *output.Printer, config *Config) (*Follower, error) {
+	reg, err := utils.GetRegistryFromRef(ref)
+	if err != nil {
+		return nil, fmt.Errorf("unable to extract registry from ref %q: %w", ref, err)
+	}
+
+	tag, err := utils.TagFromRef(ref)
+	if err != nil {
+		return nil, fmt.Errorf("unable to extract tag from ref %q: %w", ref, err)
+	}
+
+	client, err := utils.ClientForRegistry(ctx, reg, printer)
+	if err != nil {
+		return nil, err
+	}
+
+	puller := ocipuller.NewPuller(client, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create temp dir where to put pulled artifacts.
+	workingDir, err := os.MkdirTemp("", "falcoctl-")
+	if err != nil {
+		return nil, fmt.Errorf("unable to create temporary directory: %w", err)
+	}
+
+	customPrinter := printer.WithScope(ref)
+
+	return &Follower{
+		ref:        ref,
+		tag:        tag,
+		workingDir: workingDir,
+		Puller:     puller,
+		Config:     config,
+		Printer:    customPrinter,
+	}, nil
+}
+
+// Follow starts a goroutine that periodically checks for updates for the configured artifact.
+func (f *Follower) Follow(ctx context.Context) {
+	// At start up time of the follower we sync immediately without waiting the resync time.
+	f.follow(ctx)
+
+	for {
+		select {
+		case <-f.CloseChan:
+			f.cleanUp()
+			fmt.Printf("follower for %q stopped\n", f.ref)
+			// Notify that the follower is done.
+			f.WaitGroup.Done()
+			return
+		case <-time.After(f.Resync):
+			// Start following the artifact.
+			f.follow(ctx)
+		}
+	}
+}
+
+func (f *Follower) follow(ctx context.Context) {
+	// First thing get the descriptor from remote repo.
+	f.Verbosef("fetching descriptor from remote repository...")
+	desc, err := f.Descriptor(ctx, f.ref)
+	if err != nil {
+		f.Error.Printfln("an error occurred while fetching descriptor from remote repository: %v", err)
+		return
+	}
+	f.Verbosef("descriptor correctly fetched")
+
+	// If we have already processed then do nothing.
+	// TODO(alacuku): check that the file also exists to cover the case when someone has removed the file.
+	if desc.Digest.String() == f.currentDigest {
+		f.Verbosef("nothing to do, artifact already up to date.")
+		return
+	}
+
+	f.Info.Printfln("found new version under tag %q", f.tag)
+
+	f.Verbosef("pulling artifact from remote repository...")
+	// Pull the artifact from the repository.
+	filePaths, res, err := f.pull(ctx)
+	if err != nil {
+		f.Error.Printfln("an error occurred while pulling artifact from remote repository: %v", err)
+		return
+	}
+	f.Verbosef("artifact correctly pulled")
+
+	dstDir := f.destinationDir(res)
+
+	// Install the artifacts if necessary.
+	for _, path := range filePaths {
+		baseName := filepath.Base(path)
+		f.Verbosef("installing file %q...", baseName)
+		dstPath := filepath.Join(dstDir, baseName)
+		// Check if the file exists.
+		f.Verbosef("checking if file %q already exists in %q", baseName, dstDir)
+		exists, err := fileExists(dstPath)
+		if err != nil {
+			f.Error.Printfln("an error occurred while checking %q existence: %v", baseName, err)
+			return
+		}
+
+		if !exists {
+			f.Verbosef("file %q does not exist in %q, moving it", baseName, dstDir)
+			if err = os.Rename(path, dstPath); err != nil {
+				f.Error.Printfln("an error occurred while moving file %q to %q: %v", baseName, dstDir, err)
+				return
+			}
+			f.Verbosef("file %q correctly installed", path)
+			// It's done, move to the next file.
+			continue
+		}
+		f.Verbosef("file %q already exists in %q, checking if it is equal to the existing one", baseName, dstDir)
+		// Check if the files are equal.
+		equal, err := equal([]string{path, dstPath})
+		if err != nil {
+			f.Error.Printfln("an error occurred while comaparing files %q and %q: %v", path, dstPath, err)
+			return
+		}
+
+		if !equal {
+			f.Verbosef("overwriting file %q with file %q", dstPath, path)
+			if err = os.Rename(path, dstPath); err != nil {
+				f.Error.Printfln("an error occurred while overwriting file %q: %v", dstPath, err)
+				return
+			}
+		}
+		f.Verbosef("the two file are equal, nothing to be done")
+	}
+
+	f.Info.Printfln("artifact with tag %q correctly installed", f.tag)
+	f.currentDigest = desc.Digest.String()
+}
+
+// pull downloads, extracts, and installs the artifact.
+func (f *Follower) pull(ctx context.Context) (filePaths []string, res *oci.RegistryResult, err error) {
+	// Pull the artifact from the repository.
+	f.Verbosef("pulling artifact %q", f.ref)
+	res, err = f.Pull(ctx, f.ref, f.workingDir, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		return filePaths, res, fmt.Errorf("unable to pull artifact %q: %w", f.ref, err)
+	}
+
+	f.Verbosef("extracting artifact")
+	res.Filename = filepath.Join(f.workingDir, res.Filename)
+
+	file, err := os.Open(res.Filename)
+	if err != nil {
+		return filePaths, res, fmt.Errorf("unable to open file %q: %w", res.Filename, err)
+	}
+
+	// Extract artifact and move it to its destination directory
+	filePaths, err = utils.ExtractTarGz(file, f.workingDir)
+	if err != nil {
+		return filePaths, res, fmt.Errorf("unable to extract %q to %q: %w", res.Filename, f.workingDir, err)
+	}
+
+	f.Verbosef("cleaning up leftovers files")
+	err = os.Remove(res.Filename)
+	if err != nil {
+		return filePaths, res, fmt.Errorf("unable to remove file %q: %w", res.Filename, err)
+	}
+
+	return filePaths, res, err
+}
+
+// destinationDir returns the dir where to save the artifact.
+func (f *Follower) destinationDir(res *oci.RegistryResult) string {
+	var dir string
+	switch res.Type {
+	case oci.Plugin:
+		dir = f.PluginsDir
+	case oci.Rulesfile:
+		dir = f.RulefilesDir
+	}
+	return dir
+}
+
+func (f *Follower) cleanUp() {
+	if err := os.RemoveAll(f.workingDir); err != nil {
+		f.DefaultText.Printfln("an error occurred while removing working directory %q:%w", f.workingDir, err)
+	}
+}
+
+// fileExists checks if a file exists on disk.
+func fileExists(filename string) (bool, error) {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	return !info.IsDir(), nil
+}
+
+// equal checks if the two files are equal by comparing their sha256 hashes.
+func equal(files []string) (bool, error) {
+	var hashes []string
+	if len(files) != 2 {
+		return false, fmt.Errorf("expecting 2 files but got %d", len(files))
+	}
+
+	hasher := sha256.New()
+
+	for _, file := range files {
+		filePath := filepath.Clean(file)
+		f, err := os.Open(filePath)
+		if err != nil {
+			return false, err
+		}
+
+		if _, err := io.Copy(hasher, f); err != nil {
+			return false, err
+		}
+		hashes = append(hashes, string(hasher.Sum([]byte{})))
+
+		// Clean up.
+		if err := f.Close(); err != nil {
+			return false, fmt.Errorf("unable to close file %q: %w", filePath, err)
+		}
+
+		hasher.Reset()
+	}
+
+	if hashes[0] != hashes[1] {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/internal/utils/validate.go
+++ b/internal/utils/validate.go
@@ -41,6 +41,16 @@ func GetRegistryFromRef(ref string) (string, error) {
 	return ref[0:index], nil
 }
 
+// TagFromRef extracts the tag values from a ref string.
+func TagFromRef(ref string) (string, error) {
+	i := strings.Index(ref, ":")
+	if i <= 0 {
+		return "", fmt.Errorf("cannot extract tag name from ref %q", ref)
+	}
+
+	return ref[i+1:], nil
+}
+
 // ParseReference is a helper function that parse with the followig logic:
 //
 //  1. if name is the name of an artifact, it will use the merged index to compute

--- a/pkg/oci/puller/puller.go
+++ b/pkg/oci/puller/puller.go
@@ -113,6 +113,21 @@ func (p *Puller) Pull(ctx context.Context, ref, destDir, os, arch string) (*oci.
 	}, nil
 }
 
+// Descriptor retrieves the descriptor of an artifact from a remote repository.
+func (p *Puller) Descriptor(ctx context.Context, ref string) (*v1.Descriptor, error) {
+	repo, err := remote.NewRepository(ref)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create new repository with ref %s: %w", ref, err)
+	}
+	repo.Client = p.Client
+
+	desc, _, err := repo.FetchReference(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	return &desc, nil
+}
+
 func manifestFromDesc(ctx context.Context, target oras.Target, desc *v1.Descriptor) (*v1.Manifest, error) {
 	var manifest v1.Manifest
 

--- a/pkg/options/common_options.go
+++ b/pkg/options/common_options.go
@@ -72,6 +72,11 @@ func (o *CommonOptions) Initialize(cfgs ...Configs) {
 	o.Printer = output.NewPrinter(o.printerScope, o.disableStyling, o.verbose, o.writer)
 }
 
+// IsVerbose used to check if the verbose flag is set or not.
+func (o *CommonOptions) IsVerbose() bool {
+	return o.verbose
+}
+
 // AddFlags registers the common flags.
 func (o *CommonOptions) AddFlags(flags *pflag.FlagSet) {
 	flags.BoolVarP(&o.verbose, "verbose", "v", false, "Enable verbose logs (default false)")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

This PR adds the `artifact follow` command:
```bash
❯ ./falcoctl artifact follow --help
Follow a list of artifacts from remote registry. It periodically
checks if the artfacts changed and downloads the latest version based on the configured
tags.

Artifacts are passed as arguments. By just providing the name of the artifact the
command will search for the artifact in the configured index files (see index command).
If found it will use the 'registry' and 'repository' as specifiend in the index file.

Example - Install and follow "cloudtrail" plugin using the "latest" (default) tag using the info found in the index file:
        falcoctl artifact follow cloudtrail

Example - Install and follow "cloudtrail:0.6.0" plugin using the "0.6.0" tag. Here we explicitly set the tag:
        falcoctl artifact follow cloudtrail:0.6.0

Example - Install and follow "cloudtrail" plugin and "cloutrail-rules" using the "latest" (default) tag:
        falcoctl artifact follow cloudtrail cloudtrail-rules


The command also supports the references for the artifacts composed by "registry" + "repository" + "tag":

Example - Install and follow "cloudtrail" plugins using the full artifact reference:
        falcoctl artifact follow ghcr.io/falcosecurity/plugins/ruleset/cloudtrail:0.6.0-rc1

Usage:
  falcoctl artifact follow [ref1 [ref2 ...]] [flags]

Flags:
  -e, --every duration          Time interval how often it checks for a new version of the artifact (default 24h0m0s)
  -h, --help                    help for follow
      --plugins-dir string      Directory where to install plugins (default "/usr/share/falco/plugins")
      --rulesfiles-dir string   Directory where to install rules (default "/etc/falco")

Global Flags:
      --disable-styling   Disable output styling such as spinners, progress bars and colors. Styling is automatically disabled if not attacched to a tty (default false)
  -v, --verbose           Enable verbose logs (default false)
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
