### PR TITLE
chore: use default tag concurrency equal to 1

### DIFF
--- a/pkg/oci/pusher/pusher.go
+++ b/pkg/oci/pusher/pusher.go
@@ -183,7 +183,9 @@ func (p *Pusher) Push(ctx context.Context, artifactType oci.ArtifactType,
 	}
 
 	if len(o.Tags) > 0 {
-		if err = oras.TagN(ctx, remoteTarget, repo.Reference.Reference, o.Tags, oras.DefaultTagNOptions); err != nil {
+		tagNOptions := oras.DefaultTagNOptions
+		tagNOptions.Concurrency = 1
+		if err = oras.TagN(ctx, remoteTarget, repo.Reference.Reference, o.Tags, tagNOptions); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Lorenzo Susini <susinilorenzo1@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area library

> /area cli

> /area tests

> /area examples

**What this PR does / why we need it**:
Use default concurrency for tagging equal to 1. For sure this is not a bottleneck and it allows showing tags in proper order in the below section for our CI. 

![image](https://user-images.githubusercontent.com/49318629/208703865-f999d2cb-62fd-4786-8a4c-49c59369799e.png)


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
