### PR TITLE
refactor(oci/client): avoid yet another wrapper for the oci client

### DIFF
--- a/internal/utils/registry.go
+++ b/internal/utils/registry.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"golang.org/x/oauth2/clientcredentials"
+	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 
 	"github.com/falcosecurity/falcoctl/pkg/oci/authn"
@@ -49,7 +50,7 @@ func PusherForRegistry(ctx context.Context, plainHTTP, oauth bool, registry stri
 
 // ClientForRegistry returns a new auth.Client for the given registry.
 // It authenticates the client if credentials are found in the system.
-func ClientForRegistry(ctx context.Context, reg string, plainHTTP, oauth bool, printer *output.Printer) (*authn.Client, error) {
+func ClientForRegistry(ctx context.Context, reg string, plainHTTP, oauth bool, printer *output.Printer) (remote.Client, error) {
 	var cred auth.Credential
 	var conf *clientcredentials.Config
 	var err error
@@ -73,9 +74,8 @@ func ClientForRegistry(ctx context.Context, reg string, plainHTTP, oauth bool, p
 	}
 
 	client := authn.NewClient(
-		authn.WithContext(ctx),
 		authn.WithClientCredentials(conf),
-		authn.WithOauth(oauth),
+		authn.WithOauth(ctx, oauth),
 		authn.WithCredentials(&cred))
 
 	r, err := registry.NewRegistry(reg, registry.WithClient(client), registry.WithPlainHTTP(plainHTTP))

--- a/pkg/oci/platforms.go
+++ b/pkg/oci/platforms.go
@@ -21,13 +21,13 @@ import (
 	"io"
 
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/registry/remote"
 
-	"github.com/falcosecurity/falcoctl/pkg/oci/authn"
 	"github.com/falcosecurity/falcoctl/pkg/oci/repository"
 )
 
 // Platforms returns a list of all available platforms for a given ref.
-func Platforms(ctx context.Context, ref string, client *authn.Client) (map[string]struct{}, error) {
+func Platforms(ctx context.Context, ref string, client remote.Client) (map[string]struct{}, error) {
 	repo, err := repository.NewRepository(ref, repository.WithClient(client))
 	if err != nil {
 		return nil, err

--- a/pkg/oci/puller/puller.go
+++ b/pkg/oci/puller/puller.go
@@ -23,23 +23,23 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content/file"
+	"oras.land/oras-go/v2/registry/remote"
 
 	"github.com/falcosecurity/falcoctl/pkg/oci"
-	"github.com/falcosecurity/falcoctl/pkg/oci/authn"
 	"github.com/falcosecurity/falcoctl/pkg/oci/repository"
 	"github.com/falcosecurity/falcoctl/pkg/output"
 )
 
 // Puller implements pull operations.
 type Puller struct {
-	Client    *authn.Client
+	Client    remote.Client
 	tracker   output.Tracker
 	plainHTTP bool
 }
 
 // NewPuller create a new puller that can be used for pull operations.
 // The client must be ready to be used by the puller.
-func NewPuller(client *authn.Client, plainHTTP bool, tracker output.Tracker) *Puller {
+func NewPuller(client remote.Client, plainHTTP bool, tracker output.Tracker) *Puller {
 	return &Puller{
 		Client:    client,
 		tracker:   tracker,

--- a/pkg/oci/pusher/pusher.go
+++ b/pkg/oci/pusher/pusher.go
@@ -28,9 +28,9 @@ import (
 	logger "github.com/sirupsen/logrus"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content/file"
+	"oras.land/oras-go/v2/registry/remote"
 
 	"github.com/falcosecurity/falcoctl/pkg/oci"
-	"github.com/falcosecurity/falcoctl/pkg/oci/authn"
 	"github.com/falcosecurity/falcoctl/pkg/oci/repository"
 	"github.com/falcosecurity/falcoctl/pkg/output"
 )
@@ -55,13 +55,13 @@ var (
 
 // Pusher implements push operations.
 type Pusher struct {
-	Client    *authn.Client
+	Client    remote.Client
 	tracker   output.Tracker
 	plainHTTP bool
 }
 
 // NewPusher create a new pusher that can be used for push operations.
-func NewPusher(client *authn.Client, plainHTTP bool, tracker output.Tracker) *Pusher {
+func NewPusher(client remote.Client, plainHTTP bool, tracker output.Tracker) *Pusher {
 	return &Pusher{
 		Client:    client,
 		tracker:   tracker,

--- a/pkg/oci/registry/registry.go
+++ b/pkg/oci/registry/registry.go
@@ -22,8 +22,6 @@ import (
 
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
-
-	"github.com/falcosecurity/falcoctl/pkg/oci/authn"
 )
 
 // Registry is an HTTP client to interact with a remote registry.
@@ -51,9 +49,9 @@ func NewRegistry(ref string, options ...func(*Registry)) (*Registry, error) {
 }
 
 // WithClient sets the underlying HTTP client to be used for requests.
-func WithClient(client *authn.Client) func(r *Registry) {
+func WithClient(client remote.Client) func(r *Registry) {
 	return func(r *Registry) {
-		r.Client = client.Client
+		r.Client = client
 	}
 }
 

--- a/pkg/oci/repository/repository.go
+++ b/pkg/oci/repository/repository.go
@@ -20,8 +20,6 @@ import (
 
 	"github.com/blang/semver"
 	"oras.land/oras-go/v2/registry/remote"
-
-	"github.com/falcosecurity/falcoctl/pkg/oci/authn"
 )
 
 // Repository is an HTTP client to interact with a remote repository.
@@ -49,9 +47,9 @@ func NewRepository(ref string, options ...func(*Repository)) (*Repository, error
 }
 
 // WithClient sets the underlying HTTP client to be used for requests.
-func WithClient(client *authn.Client) func(r *Repository) {
+func WithClient(client remote.Client) func(r *Repository) {
 	return func(r *Repository) {
-		r.Client = client.Client
+		r.Client = client
 	}
 }
 


### PR DESCRIPTION
Co-authored-by: Lorenzo Susini <susinilorenzo1@gmail.com>
Signed-off-by: Aldo Lacuku <aldo@lacuku.eu>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

Simplify the creation of the `oci client` by returning the `remote.Client` interface instead of a custom `struct` that holds the same interface.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
