### PR TITLE
fix(pkg/oci/repository): do not error when parsing semver tags that do not strictly adhere to semver

### DIFF
--- a/pkg/oci/repository/repository.go
+++ b/pkg/oci/repository/repository.go
@@ -90,9 +90,9 @@ func sortTags(tags []string) ([]string, error) {
 			continue
 		}
 
-		parsedVersion, err := semver.Parse(t)
+		parsedVersion, err := semver.ParseTolerant(t)
 		if err != nil {
-			return nil, fmt.Errorf("cannot parse version %q", t)
+			return nil, fmt.Errorf("cannot parse version %q: %w", t, err)
 		}
 
 		parsedVersions = append(parsedVersions, parsedVersion)


### PR DESCRIPTION

Examples: v0.1, v2 should be correctly parsed.

Signed-off-by: Aldo Lacuku <aldo@lacuku.eu>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area library

> /area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

Be more tolerant when parsing tags that to not strictly adhere  to semver specification such as `v0.2 or v2`.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
