### PR TITLE
fix(linting): remove hugeParam warning

### DIFF
--- a/pkg/oci/pusher/options.go
+++ b/pkg/oci/pusher/options.go
@@ -74,7 +74,7 @@ func WithFilepathsAndPlatforms(filepaths, platforms []string) Option {
 // WithArtifactConfig sets the artifact configuration.
 //
 // Dependencies and requirements can be set by oci.ArtifactConfig.
-func WithArtifactConfig(config oci.ArtifactConfig) Option { //nolint:gocritic,hugeParam // we want to avoid indirect modification
+func WithArtifactConfig(config oci.ArtifactConfig) Option { //nolint:gocritic // we want to avoid indirect modification
 	return func(o *opts) error {
 		o.ArtifactConfig = &config
 		return nil


### PR DESCRIPTION
Signed-off-by: Aldo Lacuku <aldo@lacuku.eu>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area library

> /area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

Remove hugeParam warning when running the linter.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
