### PR TITLE
update: add retry logic when retrieving falco versions

### DIFF
--- a/internal/artifact/follow/follow.go
+++ b/internal/artifact/follow/follow.go
@@ -32,6 +32,7 @@ import (
 	"github.com/falcosecurity/falcoctl/internal/utils"
 	"github.com/falcosecurity/falcoctl/pkg/index"
 	"github.com/falcosecurity/falcoctl/pkg/options"
+	"github.com/falcosecurity/falcoctl/pkg/output"
 )
 
 const (
@@ -60,6 +61,8 @@ The command also supports the references for the artifacts composed by "registry
 Example - Install and follow "cloudtrail" plugins using the full artifact reference:
 	falcoctl artifact follow ghcr.io/falcosecurity/plugins/ruleset/cloudtrail:0.6.0-rc1
 `
+
+	maxRetry = 5
 )
 
 type artifactFollowOptions struct {
@@ -71,6 +74,7 @@ type artifactFollowOptions struct {
 	every         time.Duration
 	falcoVersions string
 	versions      config.FalcoVersions
+	timeout       time.Duration
 	closeChan     chan bool
 }
 
@@ -133,6 +137,8 @@ func NewArtifactFollowCmd(ctx context.Context, opt *options.CommonOptions) *cobr
 	cmd.Flags().StringVar(&o.workingDir, "working-dir", "", "Directory where to save temporary files")
 	cmd.Flags().StringVar(&o.falcoVersions, "falco-versions", "http://localhost:8765/versions",
 		"Where to retrieve versions, it can be either an URL or a path to a file")
+	cmd.Flags().DurationVar(&o.timeout, "timeout", defaultBackoffConfig.MaxDelay,
+		"Timeout for initial connection to the Falco versions endpoint")
 	return cmd
 }
 
@@ -242,7 +248,16 @@ func (o *artifactFollowOptions) retrieveFalcoVersions(ctx context.Context) error
 		return fmt.Errorf("cannot fetch Falco version: %w", err)
 	}
 
-	client := &http.Client{}
+	backoffConfig := defaultBackoffConfig
+	backoffConfig.MaxDelay = o.timeout
+
+	client := &http.Client{
+		Transport: &backoffTransport{
+			Base:    http.DefaultTransport,
+			Printer: o.Printer,
+			Config:  backoffConfig,
+		},
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("unable to get versions from URL %q: %w", o.falcoVersions, err)
@@ -260,4 +275,84 @@ func (o *artifactFollowOptions) retrieveFalcoVersions(ctx context.Context) error
 	}
 
 	return nil
+}
+
+// Config defines the configuration options for backoff.
+type backoffConfig struct {
+	// BaseDelay is the amount of time to backoff after the first failure.
+	BaseDelay time.Duration
+	// Multiplier is the factor with which to multiply backoffs after a
+	// failed retry. Should ideally be greater than 1.
+	Multiplier float64
+	// Jitter is the factor with which backoffs are randomized.
+	// todo: not yet implemented
+	// Jitter float64
+	// MaxDelay is the upper bound of backoff delay.
+	MaxDelay time.Duration
+}
+
+var defaultBackoffConfig = backoffConfig{
+	BaseDelay:  1.0 * time.Second,
+	Multiplier: 1.6,
+	// Jitter:     0.2, todo: not yet implemented
+	MaxDelay: 120 * time.Second,
+}
+
+type backoffTransport struct {
+	Base      http.RoundTripper
+	Printer   *output.Printer
+	Config    backoffConfig
+	attempts  int
+	startTime time.Time
+}
+
+func (bt *backoffTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	var err error
+	var resp *http.Response
+
+	bt.startTime = time.Now()
+	bt.attempts = 0
+
+	bt.Printer.Verbosef("Retrieving versions from Falco (timeout %s) ...", bt.Config.MaxDelay)
+
+	for time.Now().Sub(bt.startTime) <= bt.Config.MaxDelay {
+		resp, err = bt.Base.RoundTrip(req)
+		if err != nil {
+			sleep := bt.Config.backoff(int(bt.attempts))
+			bt.Printer.Verbosef("error: %s. Trying again in %s", err.Error(), sleep.String())
+			time.Sleep(sleep)
+		} else {
+			bt.Printer.Verbosef("Successfully retrieved versions from Falco ...")
+			return resp, err
+		}
+
+		bt.attempts++
+	}
+
+	return resp, fmt.Errorf("timeout occurred while retrieving versions from Falco")
+}
+
+// Backoff returns the amount of time to wait before the next retry given the
+// number of retries.
+func (bc backoffConfig) backoff(retries int) time.Duration {
+	if retries == 0 {
+		return bc.BaseDelay
+	}
+	backoff, max := float64(bc.BaseDelay), float64(bc.MaxDelay)
+	for backoff < max && retries > 0 {
+		backoff *= bc.Multiplier
+		retries--
+	}
+	if backoff > max {
+		backoff = max
+	}
+	// Randomize backoff delays so that if a cluster of requests start at
+	// the same time, they won't operate in lockstep.
+	// todo: implement jitter
+	// backoff *= 1 + bc.Jitter*(math.Float64()*2-1)
+	if backoff < 0 {
+		return 0
+	}
+
+	return time.Duration(backoff)
 }


### PR DESCRIPTION
Signed-off-by: Lorenzo Susini <susinilorenzo1@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area library

> /area cli

> /area tests

> /area examples

**What this PR does / why we need it**:
Since `falcoctl` can be run as sidecar container or in a systems unit, ensure that Falco has time to start up and expose the versions endpoint. This PR add a simple retry logic with exponential backoff using a custom http.RoundTripper.
It is possible to debug what is happening using the verbose flag.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
