### PR TITLE
fix: use a move function that copies content of a file if rename fails

### DIFF
--- a/internal/follower/follower.go
+++ b/internal/follower/follower.go
@@ -200,7 +200,7 @@ func (f *Follower) follow(ctx context.Context) {
 
 		if !exists {
 			f.Verbosef("file %q does not exist in %q, moving it", baseName, dstDir)
-			if err = os.Rename(path, dstPath); err != nil {
+			if err = utils.Move(path, dstPath); err != nil {
 				f.Error.Printfln("an error occurred while moving file %q to %q: %v", baseName, dstDir, err)
 				return
 			}
@@ -218,7 +218,7 @@ func (f *Follower) follow(ctx context.Context) {
 
 		if !equal {
 			f.Verbosef("overwriting file %q with file %q", dstPath, path)
-			if err = os.Rename(path, dstPath); err != nil {
+			if err = utils.Move(path, dstPath); err != nil {
 				f.Error.Printfln("an error occurred while overwriting file %q: %v", dstPath, err)
 				return
 			}

--- a/internal/utils/move.go
+++ b/internal/utils/move.go
@@ -1,0 +1,40 @@
+// Copyright 2023 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Move moves oldPath file to to newPath file. It works also on different file system types.
+func Move(oldPath, newPath string) error {
+	err := os.Rename(oldPath, newPath)
+	if err != nil {
+		// if rename fails, just do a copy
+		data, err := os.ReadFile(filepath.Clean(oldPath))
+		if err != nil {
+			return fmt.Errorf("unable to read file %s: %w", oldPath, err)
+		}
+
+		err = os.WriteFile(newPath, data, 0o600)
+		if err != nil {
+			return fmt.Errorf("unable to write to file %s: %w", newPath, err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: Lorenzo Susini <susinilorenzo1@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area library

> /area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

The `rename` system call can fail if source and destination are in different types of filesystems. In that case, just add the logic to do a manual copy of the file.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
