### PR TITLE
fix(pusher): automatically add latest only if no other tag was specified

### DIFF
--- a/pkg/oci/pusher/pusher.go
+++ b/pkg/oci/pusher/pusher.go
@@ -98,9 +98,15 @@ func (p *Pusher) Push(ctx context.Context, artifactType oci.ArtifactType,
 		return nil, err
 	}
 
+	tags := o.Tags
+
 	// Using ":latest" by default if no tag was provided.
 	if repo.Reference.Reference == "" {
-		repo.Reference.Reference = oci.DefaultTag
+		if len(tags) > 0 {
+			repo.Reference.Reference, tags = tags[0], tags[1:]
+		} else {
+			repo.Reference.Reference = oci.DefaultTag
+		}
 	}
 
 	// Set remoteTarget and its tracker.
@@ -178,7 +184,7 @@ func (p *Pusher) Push(ctx context.Context, artifactType oci.ArtifactType,
 		return nil, err
 	}
 
-	if len(o.Tags) > 0 {
+	if len(tags) > 0 {
 		tagNOptions := oras.DefaultTagNOptions
 		tagNOptions.Concurrency = 1
 		if err = oras.TagN(ctx, remoteTarget, repo.Reference.Reference, o.Tags, tagNOptions); err != nil {


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area library

**What this PR does / why we need it**:

When calling the `Push()` function, if tags are specified via `WithTags()` with a repo name without an explicit reference in the name, only the provided tags should be pushed and not `latest`. In all other cases, the behavior should not change.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
