### PR TITLE
fix(cmd): arg missing in usage message of registry auth oauth

### DIFF
--- a/cmd/registry/auth/oauth/oauth.go
+++ b/cmd/registry/auth/oauth/oauth.go
@@ -53,7 +53,7 @@ func NewOauthCmd(ctx context.Context, opt *options.CommonOptions) *cobra.Command
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "oauth",
+		Use:                   "oauth [HOSTNAME]",
 		DisableFlagsInUseLine: true,
 		Short:                 "Retrieve access and refresh tokens for OAuth2.0 client credentials flow authentication",
 		Long:                  longOauth,


### PR DESCRIPTION
Signed-off-by: Roberto Scolaro <roberto.scolaro21@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

The help message for "falcoctl registry auth oauth" command was missing the hostname parameter.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
