### PR TITLE
fix(internal): wrong config file name used

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -373,15 +373,17 @@ func Installer() (Install, error) {
 // another config setting, avoid to mistakenly update it).
 func UpdateConfigFile(key string, value interface{}, path string) error {
 	v := viper.New()
+	// we keep these for consistency, but not actually used
+	// since we explicitly set the filepath later
 	v.SetConfigName("falcoctl")
+	v.SetConfigType("yaml")
 
 	absolutePath, err := filepath.Abs(path)
 	if err != nil {
 		return err
 	}
 
-	v.AddConfigPath(filepath.Dir(absolutePath))
-	v.SetConfigType("yaml")
+	v.SetConfigFile(absolutePath)
 
 	if err := v.ReadInConfig(); err != nil {
 		return fmt.Errorf("config: error reading config file: %w", err)


### PR DESCRIPTION
Signed-off-by: Roberto Scolaro <roberto.scolaro21@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

Using `--config` parameter, the tool searched only for the default config filename ("falcoctl").

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
NONE