### PR TITLE
new(index-caching): add in-memory cache mechanism for index files

### DIFF
--- a/cmd/artifact/follow/follow.go
+++ b/cmd/artifact/follow/follow.go
@@ -261,7 +261,7 @@ func (o *artifactFollowOptions) RunArtifactFollow(ctx context.Context, args []st
 		} else {
 			o.Printer.Info.Printfln("Creating follower for %q, with check every %s", a, o.every.String())
 		}
-		ref, err := utils.ParseReference(mergedIndexes, a)
+		ref, err := o.IndexCache.ResolveReference(a)
 		if err != nil {
 			return fmt.Errorf("unable to parse artifact reference for %q: %w", a, err)
 		}

--- a/cmd/artifact/install/install.go
+++ b/cmd/artifact/install/install.go
@@ -164,7 +164,7 @@ func (o *artifactInstallOptions) RunArtifactInstall(ctx context.Context, args []
 
 	// Specify how to pull config layer for each artifact requested by user.
 	resolver := artifactConfigResolver(func(ref string) (*oci.RegistryResult, error) {
-		ref, err := utils.ParseReference(mergedIndexes, ref)
+		ref, err := o.IndexCache.ResolveReference(ref)
 		if err != nil {
 			return nil, err
 		}
@@ -191,7 +191,7 @@ func (o *artifactInstallOptions) RunArtifactInstall(ctx context.Context, args []
 
 	// Compute input to install dependencies
 	for i, arg := range args {
-		args[i], err = utils.ParseReference(mergedIndexes, arg)
+		args[i], err = o.IndexCache.ResolveReference(arg)
 		if err != nil {
 			return err
 		}
@@ -208,7 +208,7 @@ func (o *artifactInstallOptions) RunArtifactInstall(ctx context.Context, args []
 
 	// Install artifacts
 	for _, ref := range resolvedDepsRefs {
-		ref, err = utils.ParseReference(mergedIndexes, ref)
+		ref, err = o.IndexCache.ResolveReference(ref)
 		if err != nil {
 			return err
 		}

--- a/cmd/index/add/add.go
+++ b/cmd/index/add/add.go
@@ -17,7 +17,6 @@ package add
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -29,25 +28,6 @@ import (
 // IndexAddOptions contains the options for the index add command.
 type IndexAddOptions struct {
 	*options.CommonOptions
-}
-
-// Validate is used to make sure that required directories are existing in the filesystem.
-func (o *IndexAddOptions) Validate(args []string) error {
-	// TODO(loresuso): we should move this logic elsewhere
-	if _, err := os.Stat(config.FalcoctlPath); os.IsNotExist(err) {
-		err = os.MkdirAll(config.FalcoctlPath, 0o700)
-		if err != nil {
-			return err
-		}
-	}
-
-	if _, err := os.Stat(config.IndexesDir); os.IsNotExist(err) {
-		err = os.MkdirAll(config.IndexesDir, 0o700)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // NewIndexAddCmd returns the index add command.
@@ -62,9 +42,6 @@ func NewIndexAddCmd(ctx context.Context, opt *options.CommonOptions) *cobra.Comm
 		Short:                 "Add an index to the local falcoctl configuration",
 		Long:                  "Add an index to the local falcoctl configuration. Indexes are used to perform search operations for artifacts",
 		Args:                  cobra.ExactArgs(2),
-		PreRun: func(cmd *cobra.Command, args []string) {
-			o.Printer.CheckErr(o.Validate(args))
-		},
 		Run: func(cmd *cobra.Command, args []string) {
 			o.Printer.CheckErr(o.RunIndexAdd(ctx, args))
 		},

--- a/cmd/index/add/add.go
+++ b/cmd/index/add/add.go
@@ -88,7 +88,7 @@ func (o *IndexAddOptions) RunIndexAdd(ctx context.Context, args []string) error 
 		return err
 	}
 
-	if _, err := indexConfig.Get(name); err == nil {
+	if e := indexConfig.Get(name); e != nil {
 		o.Printer.Warning.Printf("%s already exists with the same configuration, skipping\n", name)
 		return nil
 	}

--- a/cmd/index/remove/remove.go
+++ b/cmd/index/remove/remove.go
@@ -41,7 +41,7 @@ func (o *indexRemoveOptions) Validate(args []string) error {
 	}
 
 	for _, name := range args {
-		if _, err := o.indexConfig.Get(name); err != nil {
+		if e := o.indexConfig.Get(name); e == nil {
 			return fmt.Errorf("cannot remove %s: %w. Check that each passed index is cached in the system", name, err)
 		}
 	}

--- a/cmd/index/update/update.go
+++ b/cmd/index/update/update.go
@@ -31,23 +31,6 @@ type indexUpdateOptions struct {
 	indexConfig *index.Config
 }
 
-func (o *indexUpdateOptions) Validate(args []string) error {
-	// Check that all the index names are actually stored in the system.
-	var err error
-	o.indexConfig, err = index.NewConfig(config.IndexesFile)
-	if err != nil {
-		return err
-	}
-
-	for _, name := range args {
-		if e := o.indexConfig.Get(name); e == nil {
-			return fmt.Errorf("index named %q not found in indexes file %q", name, config.IndexesFile)
-		}
-	}
-
-	return nil
-}
-
 // NewIndexUpdateCmd returns the index update command.
 func NewIndexUpdateCmd(ctx context.Context, opt *options.CommonOptions) *cobra.Command {
 	o := indexUpdateOptions{
@@ -60,9 +43,6 @@ func NewIndexUpdateCmd(ctx context.Context, opt *options.CommonOptions) *cobra.C
 		Short:                 "Update an existing index",
 		Long:                  "Update an existing index",
 		Args:                  cobra.MinimumNArgs(1),
-		PreRun: func(cmd *cobra.Command, args []string) {
-			o.Printer.CheckErr(o.Validate(args))
-		},
 		Run: func(cmd *cobra.Command, args []string) {
 			o.Printer.CheckErr(o.RunIndexUpdate(ctx, args))
 		},

--- a/cmd/index/update/update.go
+++ b/cmd/index/update/update.go
@@ -42,7 +42,7 @@ func (o *indexUpdateOptions) Validate(args []string) error {
 	}
 
 	for _, name := range args {
-		if _, err := o.indexConfig.Get(name); err != nil {
+		if e := o.indexConfig.Get(name); e == nil {
 			return fmt.Errorf("cannot update %s: %w. Check that each passed index is cached in the system", name, err)
 		}
 	}
@@ -80,8 +80,8 @@ func (o *indexUpdateOptions) RunIndexUpdate(ctx context.Context, args []string) 
 		nameYaml := fmt.Sprintf("%s%s", name, ".yaml")
 		indexFile := filepath.Join(config.IndexesDir, nameYaml)
 
-		indexConfigEntry, err := o.indexConfig.Get(name)
-		if err != nil {
+		indexConfigEntry := o.indexConfig.Get(name)
+		if indexConfigEntry == nil {
 			return fmt.Errorf("cannot update index %s: not found", name)
 		}
 

--- a/internal/utils/validate.go
+++ b/internal/utils/validate.go
@@ -17,11 +17,6 @@ package utils
 import (
 	"fmt"
 	"strings"
-
-	"oras.land/oras-go/v2/registry"
-
-	"github.com/falcosecurity/falcoctl/pkg/index"
-	"github.com/falcosecurity/falcoctl/pkg/oci"
 )
 
 // GetRegistryFromRef extracts the registry from a ref string.
@@ -45,67 +40,4 @@ func NameFromRef(ref string) (string, error) {
 	}
 
 	return parts[0], nil
-}
-
-// ParseReference is a helper function that parse with the followig logic:
-//
-//  1. if name is the name of an artifact, it will use the merged index to compute
-//     its reference. The tag latest is always appended.
-//     e.g "cloudtrail" -> "ghcr.io/falcosecurity/plugins/cloudtrail:latest"
-//     if instead a tag or a digest is specified, the name will be used to look up
-//     into mergedIndexes, then the tag or digest will be appended.
-//     e.g "cloudtrail:0.5.1" -> "ghcr.io/falcosecurity/plugins/cloudtrail:0.5.1"
-//     e.g "cloudtrail@sha256:123abc..." -> "ghcr.io/falcosecurity/plugins/cloudtrail@sha256:123abc...
-//
-//  2. if name is a reference without tag or digest, tag latest is appended.
-//     e.g. "ghcr.io/falcosecurity/plugins/cloudtrail" -> "ghcr.io/falcosecurity/plugins/cloudtrail:latest"
-//
-//  3. if name is a complete reference, it will be returned as is.
-func ParseReference(mergedIndexes *index.MergedIndexes, name string) (string, error) {
-	parsedRef, err := registry.ParseReference(name)
-	var ref string
-
-	switch {
-	case err != nil:
-		var entryName, tag, digest string
-
-		switch {
-		case !strings.ContainsAny(name, ":@"):
-			entryName = name
-		case strings.Contains(name, ":") && !strings.Contains(name, "@"):
-			splittedName := strings.Split(name, ":")
-			entryName = splittedName[0]
-			tag = splittedName[1]
-		case strings.Contains(name, "@"):
-			splittedName := strings.Split(name, "@")
-			entryName = splittedName[0]
-			digest = splittedName[1]
-		default:
-			return "", fmt.Errorf("cannot parse %q", name)
-		}
-
-		entry, ok := mergedIndexes.EntryByName(entryName)
-		if !ok {
-			return "", fmt.Errorf("cannot find %s among the configured indexes, skipping", name)
-		}
-
-		ref = fmt.Sprintf("%s/%s", entry.Registry, entry.Repository)
-		switch {
-		case tag == "" && digest == "":
-			ref += ":" + oci.DefaultTag
-		case tag != "":
-			ref += ":" + tag
-		case digest != "":
-			ref += "@" + digest
-		}
-
-	case parsedRef.Reference == "":
-		parsedRef.Reference = oci.DefaultTag
-		ref = parsedRef.String()
-
-	default:
-		ref = parsedRef.String()
-	}
-
-	return ref, nil
 }

--- a/pkg/index/cache/cache.go
+++ b/pkg/index/cache/cache.go
@@ -1,0 +1,315 @@
+// Copyright 2023 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/falcosecurity/falcoctl/internal/config"
+	"github.com/falcosecurity/falcoctl/internal/consts"
+	"github.com/falcosecurity/falcoctl/pkg/index"
+)
+
+// Cache manages the index files.
+type Cache struct {
+	*index.MergedIndexes
+	localIndexes     *index.Config
+	localIndexesFile string
+	indexesDir       string
+	// Track the new indexes that need to be saved locally when writing the cache to file.
+	fetchedIndexes []*index.Index
+	// Track the indexes that have been removed, needed when writing the cache to file.
+	removedIndexes []string
+}
+
+// New creates a new cache object. For each entry in the indexes.yaml file it loads the respective index file
+// found on the disk or fetches it if not found. If there is an entry in the indexes.yaml file but its index file does not exist on the disk
+// then it will error.
+func New(ctx context.Context, indexFile, indexesDir string) (*Cache, error) {
+	var err error
+	var idx *index.Index
+
+	indexConfig, err := index.NewConfig(indexFile)
+	if err != nil {
+		return nil, fmt.Errorf("an error occurred while loading index file %q from disk: %w", indexFile, err)
+	}
+
+	c := &Cache{
+		localIndexes:     indexConfig,
+		localIndexesFile: indexFile,
+		indexesDir:       indexesDir,
+		MergedIndexes:    index.NewMergedIndexes(),
+	}
+
+	// Load existing indexes in memory and merge them.
+	for _, cfg := range c.localIndexes.Configs {
+		// If the index is in the local persistent cache we just load it.
+		if idx, err = c.loadIndex(cfg.Name); err != nil && errors.Is(err, fs.ErrNotExist) {
+			// If the index is not found in the local persistent cache we fetch it from the url.
+			ts := time.Now().Format(consts.TimeFormat)
+			if idx, err = index.Fetch(ctx, cfg.URL, cfg.Name); err != nil {
+				return nil, fmt.Errorf("unable to fetch index %q with URL %q: %w", cfg.Name, cfg.URL, err)
+			}
+			// If correctly fetched, we need to update the metadata of the config entry.
+			cfg.UpdatedTimestamp = ts
+			if cfg.AddedTimestamp == "" {
+				cfg.AddedTimestamp = ts
+			}
+			c.localIndexes.Upsert(cfg)
+			c.fetchedIndexes = append(c.fetchedIndexes, idx)
+		} else if err != nil {
+			return nil, fmt.Errorf("an error occurred while loading cache from disk: %w", err)
+		}
+		// After a successful load/fetch we merge it.
+		c.Merge(idx)
+	}
+
+	return c, nil
+}
+
+// NewFromConfig creates a new cache object from a set of indexes. The new cache fetches the indexes only if they do not
+// exist in the filesystem. The local indexes info is ignored, it takes into account the indexes passed as arguments.
+func NewFromConfig(ctx context.Context, indexFile, indexesDir string, indexes []config.Index) (*Cache, error) {
+	var err error
+	var idx *index.Index
+	indexConfig := &index.Config{}
+
+	c := &Cache{
+		localIndexes:     indexConfig,
+		localIndexesFile: indexFile,
+		indexesDir:       indexesDir,
+		MergedIndexes:    index.NewMergedIndexes(),
+	}
+
+	for _, cfg := range indexes {
+		// If the index is in the local persistent cache we just load it.
+		ts := time.Now().Format(consts.TimeFormat)
+		if idx, err = c.loadIndex(cfg.Name); err != nil && errors.Is(err, fs.ErrNotExist) {
+			// If the index is not found in the local persistent cache we fetch it from the url.
+			if idx, err = index.Fetch(ctx, cfg.URL, cfg.Name); err != nil {
+				return nil, fmt.Errorf("unable to fetch index %q with URL %q: %w", cfg.Name, cfg.URL, err)
+			}
+			c.fetchedIndexes = append(c.fetchedIndexes, idx)
+		} else if err != nil {
+			return nil, fmt.Errorf("an error occurred while loading cache from disk: %w", err)
+		}
+		c.localIndexes.Configs = append(c.localIndexes.Configs, index.ConfigEntry{
+			AddedTimestamp:   ts,
+			Name:             cfg.Name,
+			UpdatedTimestamp: ts,
+			URL:              cfg.URL,
+		})
+		// After a successful load/fetch we merge it.
+		c.Merge(idx)
+	}
+
+	return c, nil
+}
+
+// Add adds a new index file to the cache. If the index file already exists in the cache it
+// does nothing. On the other hand, it fetches the index file using the provided URL and adds
+// it to the in memory cache. It does not write it to the filesystem. It is idempotent.
+func (c *Cache) Add(ctx context.Context, name, url string) error {
+	var remoteIndex *index.Index
+	var err error
+
+	entry := c.localIndexes.Get(name)
+
+	// If it exists already, return.
+	if entry != nil {
+		return nil
+	}
+
+	// If the index is not locally cached we fetch it using the provided url.
+	if remoteIndex, err = index.Fetch(ctx, url, name); err != nil {
+		return fmt.Errorf("unable to fetch index %q with URL %q: %w", name, url, err)
+	}
+
+	// Keep track of the newly created index file.
+	ts := time.Now().Format(consts.TimeFormat)
+	entry = &index.ConfigEntry{
+		Name:             remoteIndex.Name,
+		AddedTimestamp:   ts,
+		UpdatedTimestamp: ts,
+		URL:              url,
+	}
+	c.localIndexes.Add(*entry)
+
+	// Save it for later write operation.
+	c.fetchedIndexes = append(c.fetchedIndexes, remoteIndex)
+
+	c.Merge(remoteIndex)
+
+	// If the index has been removed before we make sure to delete it from the removedIndexes array.
+	for i, idxName := range c.removedIndexes {
+		if idxName == name {
+			c.removedIndexes = append(c.removedIndexes[:i], c.removedIndexes[i+1:]...)
+		}
+	}
+
+	return nil
+}
+
+// Remove removes an index file from the cache if it exists.
+func (c *Cache) Remove(name string) error {
+	var idx *index.Index
+	var err error
+	newMergedIndex := index.NewMergedIndexes()
+	// Check if the index is in the local cache.
+	entry := c.localIndexes.Get(name)
+	if entry == nil {
+		return nil
+	}
+
+	// Create a new merged indexes without the one we are removing.
+	for _, cfg := range c.localIndexes.Configs {
+		if cfg.Name != name {
+			if idx, err = c.loadIndex(cfg.Name); err != nil && errors.Is(err, fs.ErrNotExist) {
+				idx = findIndexInSlice(c.fetchedIndexes, cfg.Name)
+				if idx == nil {
+					return fmt.Errorf("index %q not found in the local persisten storage neither in the fetched indexes", cfg.Name)
+				}
+			} else if err != nil {
+				return err
+			}
+			newMergedIndex.Merge(idx)
+		}
+	}
+
+	c.MergedIndexes = newMergedIndex
+	c.removedIndexes = append(c.removedIndexes, name)
+
+	// Remove the index from the indexes list.
+	c.localIndexes.Remove(name)
+
+	// Remove the index from the fetchedIndexes if present.
+	for i, idx := range c.fetchedIndexes {
+		if idx.Name == name {
+			c.fetchedIndexes = append(c.fetchedIndexes[:i], c.fetchedIndexes[i+1:]...)
+		}
+	}
+
+	return nil
+}
+
+// Update updates an index entry by fetching the new content from the configured URL for the
+// given index. The new content is kept in memory, it does not overwrite the existing index file
+// on the disk.
+func (c *Cache) Update(ctx context.Context, name string) error {
+	var idx *index.Index
+	var err error
+	newMergedIndex := index.NewMergedIndexes()
+	// Check if the entry exists.
+	entry := c.localIndexes.Get(name)
+	if entry == nil {
+		return fmt.Errorf("unable to update index %s: not found in the cache, please make sure to add it before updating", name)
+	}
+
+	ts := time.Now().Format(consts.TimeFormat)
+	// Fetch the index from the remote url.
+	updatedIndex, err := index.Fetch(ctx, entry.URL, name)
+	if err != nil {
+		return fmt.Errorf("unable to fetch index %q with URL %q: %w", name, entry.URL, err)
+	}
+
+	// Update the existing index entry by setting the new timestamp.
+	entry.UpdatedTimestamp = ts
+	c.localIndexes.Upsert(*entry)
+
+	// Track the new fetched index for writing purposes.
+	c.fetchedIndexes = append(c.fetchedIndexes, updatedIndex)
+
+	// Create a new merged indexes without the one we are removing.
+	for _, cfg := range c.localIndexes.Configs {
+		if cfg.Name != name {
+			if idx, err = c.loadIndex(cfg.Name); err != nil && errors.Is(err, fs.ErrNotExist) {
+				idx = findIndexInSlice(c.fetchedIndexes, cfg.Name)
+				if idx == nil {
+					return fmt.Errorf("index %q not found in the local persisten storage neither in the fetched indexes", cfg.Name)
+				}
+			} else if err != nil {
+				return err
+			}
+			newMergedIndex.Merge(idx)
+		} else {
+			newMergedIndex.Merge(updatedIndex)
+		}
+	}
+
+	return nil
+}
+
+// Write dumps the in-memory cache to disk. Based on the cache operations it does different things.
+// Add: a new entry is added to the config.IndexesFile and the fetched index file is saved under the
+// config.IndexesDir.
+// Remove: the removed entry is wiped out from the config.IndexesFile and the related index file is deleted.
+// Update: the entry in the config.IndexesFile for the updated index is updated. The related index file is
+// replaced by the new content fetched by the update operation.
+// Returns the index.Config written to the config.IndexesFile.
+func (c *Cache) Write() (*index.Config, error) {
+	for _, idx := range c.fetchedIndexes {
+		indexFileName := fmt.Sprintf("%s%s", idx.Name, ".yaml")
+		indexPath := filepath.Join(c.indexesDir, indexFileName)
+
+		// Save the new index.
+		if err := idx.Write(indexPath); err != nil {
+			return nil, fmt.Errorf("an error occurred while writing index %q to file %q: %w", idx.Name, indexPath, err)
+		}
+	}
+
+	for _, name := range c.removedIndexes {
+		indexFileName := fmt.Sprintf("%s%s", name, ".yaml")
+		indexPath := filepath.Join(c.indexesDir, indexFileName)
+		if err := os.Remove(indexPath); err != nil {
+			return nil, fmt.Errorf("an error occurred while removeing index %q from %q: %w", name, indexPath, err)
+		}
+		c.localIndexes.Remove(name)
+	}
+
+	if err := c.localIndexes.Write(c.localIndexesFile); err != nil {
+		return nil, fmt.Errorf("an error occurred while writing indexes file to path %q: %w", c.localIndexesFile, err)
+	}
+
+	return c.localIndexes, nil
+}
+
+func (c *Cache) loadIndex(name string) (*index.Index, error) {
+	indexFileName := fmt.Sprintf("%s%s", name, ".yaml")
+
+	idx := index.New(name)
+	indexPath := filepath.Join(c.indexesDir, indexFileName)
+	err := idx.Read(indexPath)
+	if err != nil {
+		return nil, fmt.Errorf("an error occurred while loading index %q from file %q: %w", name, indexPath, err)
+	}
+
+	return idx, nil
+}
+
+func findIndexInSlice(indexes []*index.Index, name string) *index.Index {
+	for _, idx := range indexes {
+		if idx.Name == name {
+			return idx
+		}
+	}
+
+	return nil
+}

--- a/pkg/index/cache/doc.go
+++ b/pkg/index/cache/doc.go
@@ -1,0 +1,19 @@
+// Copyright 2023 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cache implements in memory cache for the index files. At creation time, a cache
+// object loads in memory the index files if any is found on disk. Otherwise, it starts blank.
+// A cache object allow to add, remove, update index files. If necessary it allows to persist
+// the cache to disk.
+package cache

--- a/pkg/index/config.go
+++ b/pkg/index/config.go
@@ -15,6 +15,8 @@
 package index
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -97,14 +99,24 @@ func (c *Config) Get(name string) *ConfigEntry {
 	return nil
 }
 
-// Write writes an Config to disk.
+// Write writes a Config to disk.
 func (c *Config) Write(path string) error {
+	// Get dir path.
+	dir, _ := filepath.Split(path)
+	// Create directory if it does not exist.
+	if _, err := os.Stat(dir); errors.Is(err, fs.ErrNotExist) {
+		err = os.MkdirAll(dir, defaultDirPermissions) // #nosec G301 //we want 755 permissions
+		if err != nil {
+			return err
+		}
+	}
+
 	data, err := yaml.Marshal(c)
 	if err != nil {
 		return err
 	}
 
-	err = os.WriteFile(path, data, writePermissions)
+	err = os.WriteFile(path, data, defaultFilePermissions)
 	if err != nil {
 		return err
 	}

--- a/pkg/index/config.go
+++ b/pkg/index/config.go
@@ -15,7 +15,6 @@
 package index
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -66,16 +65,25 @@ func (c *Config) Add(entry ConfigEntry) {
 	c.Configs = append(c.Configs, entry)
 }
 
+// Upsert replaces the entry if already exists otherwise just appends it.
+func (c *Config) Upsert(entry ConfigEntry) {
+	for i, e := range c.Configs {
+		if entry.Name == e.Name {
+			c.Configs[i] = entry
+			return
+		}
+	}
+	c.Add(entry)
+}
+
 // Remove removes a config by name from an Config.
-func (c *Config) Remove(name string) error {
+func (c *Config) Remove(name string) {
 	for k, conf := range c.Configs {
 		if conf.Name == name {
 			c.Configs = append(c.Configs[:k], c.Configs[k+1:]...)
-			return nil
+			break
 		}
 	}
-
-	return fmt.Errorf("cannot remove index %s: not found", name)
 }
 
 // Get returns a pointer to an entry in a Config.

--- a/pkg/index/config.go
+++ b/pkg/index/config.go
@@ -79,14 +79,14 @@ func (c *Config) Remove(name string) error {
 }
 
 // Get returns a pointer to an entry in a Config.
-func (c *Config) Get(name string) (*ConfigEntry, error) {
+func (c *Config) Get(name string) *ConfigEntry {
 	for k, conf := range c.Configs {
 		if conf.Name == name {
-			return &c.Configs[k], nil
+			return &c.Configs[k]
 		}
 	}
 
-	return nil, fmt.Errorf("not found")
+	return nil
 }
 
 // Write writes an Config to disk.

--- a/pkg/index/constants.go
+++ b/pkg/index/constants.go
@@ -15,5 +15,6 @@
 package index
 
 const (
-	writePermissions = 0o600
+	defaultFilePermissions = 0o644
+	defaultDirPermissions  = 0o755
 )

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -23,6 +23,9 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+	"oras.land/oras-go/v2/registry"
+
+	"github.com/falcosecurity/falcoctl/pkg/oci"
 )
 
 // Entry describes an entry of the index stored remotely and cached locally.
@@ -220,6 +223,69 @@ func (i *Index) SearchByKeywords(minScore float64, keywords ...string) []*Entry 
 // IndexByEntry is used to retrieve the original index from an entry in MergedIndexes.
 func (m *MergedIndexes) IndexByEntry(entry *Entry) *Index {
 	return m.indexByEntry[entry]
+}
+
+// ResolveReference is a helper function that parse with the followig logic:
+//
+//  1. if name is the name of an artifact, it will use the merged index to compute
+//     its reference. The tag latest is always appended.
+//     e.g "cloudtrail" -> "ghcr.io/falcosecurity/plugins/cloudtrail:latest"
+//     if instead a tag or a digest is specified, the name will be used to look up
+//     into mergedIndexes, then the tag or digest will be appended.
+//     e.g "cloudtrail:0.5.1" -> "ghcr.io/falcosecurity/plugins/cloudtrail:0.5.1"
+//     e.g "cloudtrail@sha256:123abc..." -> "ghcr.io/falcosecurity/plugins/cloudtrail@sha256:123abc...
+//
+//  2. if name is a reference without tag or digest, tag latest is appended.
+//     e.g. "ghcr.io/falcosecurity/plugins/cloudtrail" -> "ghcr.io/falcosecurity/plugins/cloudtrail:latest"
+//
+//  3. if name is a complete reference, it will be returned as is.
+func (m *MergedIndexes) ResolveReference(name string) (string, error) {
+	parsedRef, err := registry.ParseReference(name)
+	var ref string
+
+	switch {
+	case err != nil:
+		var entryName, tag, digest string
+
+		switch {
+		case !strings.ContainsAny(name, ":@"):
+			entryName = name
+		case strings.Contains(name, ":") && !strings.Contains(name, "@"):
+			splittedName := strings.Split(name, ":")
+			entryName = splittedName[0]
+			tag = splittedName[1]
+		case strings.Contains(name, "@"):
+			splittedName := strings.Split(name, "@")
+			entryName = splittedName[0]
+			digest = splittedName[1]
+		default:
+			return "", fmt.Errorf("cannot parse %q", name)
+		}
+
+		entry, ok := m.EntryByName(entryName)
+		if !ok {
+			return "", fmt.Errorf("cannot find %s among the configured indexes, skipping", name)
+		}
+
+		ref = fmt.Sprintf("%s/%s", entry.Registry, entry.Repository)
+		switch {
+		case tag == "" && digest == "":
+			ref += ":" + oci.DefaultTag
+		case tag != "":
+			ref += ":" + tag
+		case digest != "":
+			ref += "@" + digest
+		}
+
+	case parsedRef.Reference == "":
+		parsedRef.Reference = oci.DefaultTag
+		ref = parsedRef.String()
+
+	default:
+		ref = parsedRef.String()
+	}
+
+	return ref, nil
 }
 
 // levenshteinDistance computes the edit distance between two strings.

--- a/pkg/index/index_test.go
+++ b/pkg/index/index_test.go
@@ -250,6 +250,13 @@ func TestConfig(t *testing.T) {
 		t.Error(err)
 	}
 
+	c.Remove("test")
+	for _, item := range c.Configs {
+		if item.Name == "test" {
+			t.Error(fmt.Errorf("entry \"test\" should have been removed"))
+		}
+	}
+
 	c.Add(ConfigEntry{
 		Name: "test",
 		URL:  "https://test.com/index.yaml",
@@ -260,8 +267,4 @@ func TestConfig(t *testing.T) {
 		t.Error(fmt.Errorf("entry \"test\" not found"))
 	}
 
-	err = c.Remove("test")
-	if err != nil {
-		t.Error(err)
-	}
 }

--- a/pkg/index/index_test.go
+++ b/pkg/index/index_test.go
@@ -255,9 +255,9 @@ func TestConfig(t *testing.T) {
 		URL:  "https://test.com/index.yaml",
 	})
 
-	_, err = c.Get("test")
-	if err != nil {
-		t.Error(err)
+	entry := c.Get("test")
+	if entry == nil {
+		t.Error(fmt.Errorf("entry \"test\" not found"))
 	}
 
 	err = c.Remove("test")

--- a/pkg/options/common_options.go
+++ b/pkg/options/common_options.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/falcosecurity/falcoctl/internal/config"
+	"github.com/falcosecurity/falcoctl/pkg/index/cache"
 	"github.com/falcosecurity/falcoctl/pkg/output"
 )
 
@@ -41,6 +42,8 @@ type CommonOptions struct {
 	// Config file. It must not be possible to be reinitialized by subcommands,
 	// using the Initialize function. It will be attached as global flags.
 	ConfigFile string
+	// IndexCache caches the entries for the configured indexes.
+	IndexCache *cache.Cache
 }
 
 // NewOptions returns a new CommonOptions struct.
@@ -62,6 +65,13 @@ func WithPrinterScope(scope string) Configs {
 func WithWriter(writer io.Writer) Configs {
 	return func(options *CommonOptions) {
 		options.writer = writer
+	}
+}
+
+// WithIndexCache sets the index cache.
+func WithIndexCache(c *cache.Cache) Configs {
+	return func(options *CommonOptions) {
+		options.IndexCache = c
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

Since index files can be overwritten using ENV variables we needed a new solution to handle them on a per-command basis. Added an in-memory caching system that controls the index files during the command execution.
Furthermore, it handles loading and saving the index cache from/to the filesystem.
The files that track the indexes are saved to ~/.config/falcoctl.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
