### PR TITLE
fix: create artifact destination dir if not present

### DIFF
--- a/cmd/artifact/follow/follow.go
+++ b/cmd/artifact/follow/follow.go
@@ -151,6 +151,10 @@ func NewArtifactFollowCmd(ctx context.Context, opt *options.CommonOptions) *cobr
 					o.Printer.CheckErr(fmt.Errorf("unable to overwrite \"rulesfiles-dir\" flag: %w", err))
 				}
 			}
+			// Check if directory exists and is writable
+			if err := utils.ExistsAndIsWritable(f.Value.String()); err != nil {
+				o.Printer.CheckErr(fmt.Errorf("rulesfiles-dir: %w", err))
+			}
 
 			// Override "plugins-dir" flag with viper config if not set by user.
 			f = cmd.Flags().Lookup("plugins-dir")
@@ -162,6 +166,10 @@ func NewArtifactFollowCmd(ctx context.Context, opt *options.CommonOptions) *cobr
 				if err := cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val)); err != nil {
 					o.Printer.CheckErr(fmt.Errorf("unable to overwrite \"plugins-dir\" flag: %w", err))
 				}
+			}
+			// Check if directory exists and is writable
+			if err := utils.ExistsAndIsWritable(f.Value.String()); err != nil {
+				o.Printer.CheckErr(fmt.Errorf("plugins-dir: %w", err))
 			}
 
 			// Override "tmp-dir" flag with viper config if not set by user.

--- a/cmd/artifact/install/install.go
+++ b/cmd/artifact/install/install.go
@@ -239,6 +239,13 @@ func (o *artifactInstallOptions) RunArtifactInstall(ctx context.Context, args []
 			destDir = o.rulesfilesDir
 		}
 
+		if _, err = os.Stat(destDir); os.IsNotExist(err) {
+			err = os.MkdirAll(destDir, 0o700)
+			if err != nil {
+				return err
+			}
+		}
+
 		sp, _ := o.Printer.Spinner.Start(fmt.Sprintf("INFO: Extracting and installing %q %q", result.Type, result.Filename))
 		result.Filename = filepath.Join(tmpDir, result.Filename)
 

--- a/internal/follower/follower.go
+++ b/internal/follower/follower.go
@@ -188,6 +188,14 @@ func (f *Follower) follow(ctx context.Context) {
 
 	dstDir := f.destinationDir(res)
 
+	if _, err := os.Stat(dstDir); os.IsNotExist(err) {
+		err = os.MkdirAll(dstDir, 0o700)
+		if err != nil {
+			f.Error.Printfln("cannot create destination directory for the artifact: %v", err)
+			return
+		}
+	}
+
 	// Install the artifacts if necessary.
 	for _, path := range filePaths {
 		baseName := filepath.Base(path)
@@ -275,6 +283,7 @@ func (f *Follower) destinationDir(res *oci.RegistryResult) string {
 	case oci.Rulesfile:
 		dir = f.RulesfilesDir
 	}
+
 	return dir
 }
 

--- a/internal/follower/follower.go
+++ b/internal/follower/follower.go
@@ -188,14 +188,6 @@ func (f *Follower) follow(ctx context.Context) {
 
 	dstDir := f.destinationDir(res)
 
-	if _, err := os.Stat(dstDir); os.IsNotExist(err) {
-		err = os.MkdirAll(dstDir, 0o700)
-		if err != nil {
-			f.Error.Printfln("cannot create destination directory for the artifact: %v", err)
-			return
-		}
-	}
-
 	// Install the artifacts if necessary.
 	for _, path := range filePaths {
 		baseName := filepath.Base(path)
@@ -283,7 +275,6 @@ func (f *Follower) destinationDir(res *oci.RegistryResult) string {
 	case oci.Rulesfile:
 		dir = f.RulesfilesDir
 	}
-
 	return dir
 }
 

--- a/internal/utils/fs.go
+++ b/internal/utils/fs.go
@@ -15,6 +15,7 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -34,6 +35,33 @@ func Move(oldPath, newPath string) error {
 		if err != nil {
 			return fmt.Errorf("unable to write to file %s: %w", newPath, err)
 		}
+	}
+
+	return nil
+}
+
+// ExistsAndIsWritable checks if the directory specified by the path exists and is writable.
+func ExistsAndIsWritable(path string) error {
+	info, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("%s doesn't exists", path)
+	} else if err != nil {
+		return err
+	}
+
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", path)
+	}
+
+	if f, err := os.Create(filepath.Join(filepath.Clean(path), "._check_writable")); err == nil {
+		if err := f.Close(); err != nil {
+			return err
+		}
+		if err := os.Remove(f.Name()); err != nil {
+			return err
+		}
+	} else {
+		return fmt.Errorf("%s is not writable", path)
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Roberto Scolaro <roberto.scolaro21@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

> /area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

If the destination directory for the artifacts (`--rulesfiles-dir` or `--plugins-dir`) doesn't exist, the command fails.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
NONE