### PR TITLE
fix: use index cache in artifact commands

### DIFF
--- a/cmd/artifact/list/artifact_list.go
+++ b/cmd/artifact/list/artifact_list.go
@@ -19,9 +19,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/falcosecurity/falcoctl/internal/config"
-	"github.com/falcosecurity/falcoctl/internal/utils"
-	"github.com/falcosecurity/falcoctl/pkg/index"
 	"github.com/falcosecurity/falcoctl/pkg/oci"
 	"github.com/falcosecurity/falcoctl/pkg/options"
 	"github.com/falcosecurity/falcoctl/pkg/output"
@@ -57,23 +54,13 @@ func NewArtifactListCmd(ctx context.Context, opt *options.CommonOptions) *cobra.
 }
 
 func (o *artifactListOptions) RunArtifactList(ctx context.Context, args []string) error {
-	indexConfig, err := index.NewConfig(config.IndexesFile)
-	if err != nil {
-		return err
-	}
-
-	mergedIndexes, err := utils.Indexes(indexConfig, config.IndexesDir)
-	if err != nil {
-		return err
-	}
-
 	var data [][]string
-	for _, entry := range mergedIndexes.Entries {
+	for _, entry := range o.IndexCache.MergedIndexes.Entries {
 		if o.artifactType != "" && o.artifactType != oci.ArtifactType(entry.Type) {
 			continue
 		}
 
-		indexName := mergedIndexes.IndexByEntry(entry).Name
+		indexName := o.IndexCache.MergedIndexes.IndexByEntry(entry).Name
 		if o.index != "" && o.index != indexName {
 			continue
 		}
@@ -82,7 +69,7 @@ func (o *artifactListOptions) RunArtifactList(ctx context.Context, args []string
 		data = append(data, row)
 	}
 
-	if err = o.Printer.PrintTable(output.ArtifactSearch, data); err != nil {
+	if err := o.Printer.PrintTable(output.ArtifactSearch, data); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: Lorenzo Susini <susinilorenzo1@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:
Also `artifact search` and `artifact list` commands need to use the configured indexes to provide their output.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
