### PR TITLE
refactor(cmd/artifact): share flags and cleanup descriptions

### DIFF
--- a/cmd/artifact/follow/follow.go
+++ b/cmd/artifact/follow/follow.go
@@ -147,32 +147,32 @@ func NewArtifactFollowCmd(ctx context.Context, opt *options.CommonOptions) *cobr
 			f = cmd.Flags().Lookup(install.FlagRulesFilesDir)
 			if f == nil {
 				// should never happen
-				o.Printer.CheckErr(fmt.Errorf("unable to retrieve flag %s", install.FlagRulesFilesDir))
+				o.Printer.CheckErr(fmt.Errorf("unable to retrieve flag %q", install.FlagRulesFilesDir))
 			} else if !f.Changed && viper.IsSet(config.ArtifactFollowRulesfilesDirKey) {
 				val := viper.Get(config.ArtifactFollowRulesfilesDirKey)
 				if err := cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val)); err != nil {
-					o.Printer.CheckErr(fmt.Errorf("unable to overwrite \"%s\" flag: %w", install.FlagRulesFilesDir, err))
+					o.Printer.CheckErr(fmt.Errorf("unable to overwrite %q flag: %w", install.FlagRulesFilesDir, err))
 				}
 			}
 			// Check if directory exists and is writable
 			if err := utils.ExistsAndIsWritable(f.Value.String()); err != nil {
-				o.Printer.CheckErr(fmt.Errorf("%s: %w", install.FlagRulesFilesDir, err))
+				o.Printer.CheckErr(fmt.Errorf("%q: %w", install.FlagRulesFilesDir, err))
 			}
 
 			// Override "plugins-dir" flag with viper config if not set by user.
 			f = cmd.Flags().Lookup(install.FlagPluginsFilesDir)
 			if f == nil {
 				// should never happen
-				o.Printer.CheckErr(fmt.Errorf("unable to retrieve flag %s", install.FlagPluginsFilesDir))
+				o.Printer.CheckErr(fmt.Errorf("unable to retrieve flag %q", install.FlagPluginsFilesDir))
 			} else if !f.Changed && viper.IsSet(config.ArtifactFollowPluginsDirKey) {
 				val := viper.Get(config.ArtifactFollowPluginsDirKey)
 				if err := cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val)); err != nil {
-					o.Printer.CheckErr(fmt.Errorf("unable to overwrite \"%s\" flag: %w", install.FlagPluginsFilesDir, err))
+					o.Printer.CheckErr(fmt.Errorf("unable to overwrite %q flag: %w", install.FlagPluginsFilesDir, err))
 				}
 			}
 			// Check if directory exists and is writable
 			if err := utils.ExistsAndIsWritable(f.Value.String()); err != nil {
-				o.Printer.CheckErr(fmt.Errorf("%s: %w", install.FlagPluginsFilesDir, err))
+				o.Printer.CheckErr(fmt.Errorf("%q: %w", install.FlagPluginsFilesDir, err))
 			}
 
 			// Override "tmp-dir" flag with viper config if not set by user.
@@ -198,7 +198,7 @@ func NewArtifactFollowCmd(ctx context.Context, opt *options.CommonOptions) *cobr
 					o.Printer.CheckErr(err)
 				}
 				if err := cmd.Flags().Set(f.Name, val.String()); err != nil {
-					o.Printer.CheckErr(fmt.Errorf("unable to overwrite \"%s\" flag: %w", install.FlagAllowedTypes, err))
+					o.Printer.CheckErr(fmt.Errorf("unable to overwrite %q flag: %w", install.FlagAllowedTypes, err))
 				}
 			}
 

--- a/cmd/artifact/install/constants.go
+++ b/cmd/artifact/install/constants.go
@@ -1,0 +1,8 @@
+package install
+
+const (
+	FlagRulesFilesDir   = "rulesfiles-dir"
+	FlagPluginsFilesDir = "plugins-dir"
+	FlagAllowedTypes    = "allowed-types"
+	FlagResolveDeps     = "resolve-deps"
+)

--- a/cmd/artifact/install/constants.go
+++ b/cmd/artifact/install/constants.go
@@ -1,8 +1,30 @@
+// Copyright 2023 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package install
 
 const (
-	FlagRulesFilesDir   = "rulesfiles-dir"
+
+	// FlagRulesFilesDir is the name of the flag to specify the directory path of the rules files.
+	FlagRulesFilesDir = "rulesfiles-dir"
+
+	// FlagPluginsFilesDir is the name of the flag to specify the directory path of the plugins.
 	FlagPluginsFilesDir = "plugins-dir"
-	FlagAllowedTypes    = "allowed-types"
-	FlagResolveDeps     = "resolve-deps"
+
+	// FlagAllowedTypes is the name of the flag to specify allowed artifact types.
+	FlagAllowedTypes = "allowed-types"
+
+	// FlagResolveDeps is the name of the flag to enable artifact dependencies resolution.
+	FlagResolveDeps = "resolve-deps"
 )

--- a/cmd/artifact/install/install.go
+++ b/cmd/artifact/install/install.go
@@ -157,15 +157,15 @@ func NewArtifactInstallCmd(ctx context.Context, opt *options.CommonOptions) *cob
 
 	o.RegistryOptions.AddFlags(cmd)
 	cmd.Flags().StringVarP(&o.rulesfilesDir, FlagRulesFilesDir, "", config.RulesfilesDir,
-		"directory where to install rules. Defaults to /etc/falco")
+		"directory where to install rules.")
 	cmd.Flags().StringVarP(&o.pluginsDir, FlagPluginsFilesDir, "", config.PluginsDir,
-		"directory where to install plugins. Defaults to /usr/share/falco/plugins")
+		"directory where to install plugins.")
 	cmd.Flags().Var(&o.allowedTypes, FlagAllowedTypes,
 		fmt.Sprintf(`list of artifact types that can be installed. If not specified or configured, all types are allowed.
 It accepts comma separated values or it can be repeated multiple times.
 Examples: 
 	--%s="rulesfile,plugin"
-	--%s=rulesfile --%s=plugin`, FlagAllowedTypes))
+	--%s=rulesfile --%s=plugin`, FlagAllowedTypes, FlagAllowedTypes, FlagAllowedTypes))
 	cmd.Flags().BoolVar(&o.resolveDeps, FlagResolveDeps, true,
 		"whether this command should resolve dependencies or not")
 

--- a/cmd/artifact/install/install.go
+++ b/cmd/artifact/install/install.go
@@ -88,61 +88,65 @@ func NewArtifactInstallCmd(ctx context.Context, opt *options.CommonOptions) *cob
 		Short:                 "Install a list of artifacts",
 		Long:                  longInstall,
 		PreRun: func(cmd *cobra.Command, args []string) {
+
 			// Override "rulesfiles-dir" flag with viper config if not set by user.
-			f := cmd.Flags().Lookup("rulesfiles-dir")
+			f := cmd.Flags().Lookup(FlagRulesFilesDir)
 			if f == nil {
 				// should never happen
-				o.Printer.CheckErr(fmt.Errorf("unable to retrieve flag rulesfiles-dir"))
+				o.Printer.CheckErr(fmt.Errorf("unable to retrieve flag %s", FlagRulesFilesDir))
 			} else if !f.Changed && viper.IsSet(config.ArtifactInstallRulesfilesDirKey) {
+
 				val := viper.Get(config.ArtifactInstallRulesfilesDirKey)
 				if err := cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val)); err != nil {
-					o.Printer.CheckErr(fmt.Errorf("unable to overwrite \"rulesfiles-dir\" flag: %w", err))
+					o.Printer.CheckErr(fmt.Errorf("unable to overwrite \"%s\" flag: %w", FlagRulesFilesDir, err))
 				}
 			}
-			// Check if directory exists and is writable
+
+			// Check if directory exists and is writable.
 			if err := utils.ExistsAndIsWritable(f.Value.String()); err != nil {
-				o.Printer.CheckErr(fmt.Errorf("rulesfiles-dir: %w", err))
+				o.Printer.CheckErr(fmt.Errorf("%s: %w", FlagRulesFilesDir, err))
 			}
 
 			// Override "plugins-dir" flag with viper config if not set by user.
-			f = cmd.Flags().Lookup("plugins-dir")
+			f = cmd.Flags().Lookup(FlagPluginsFilesDir)
 			if f == nil {
 				// should never happen
-				o.Printer.CheckErr(fmt.Errorf("unable to retrieve flag plugins-dir"))
+				o.Printer.CheckErr(fmt.Errorf("unable to retrieve flag %s", FlagPluginsFilesDir))
 			} else if !f.Changed && viper.IsSet(config.ArtifactInstallPluginsDirKey) {
 				val := viper.Get(config.ArtifactInstallPluginsDirKey)
 				if err := cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val)); err != nil {
-					o.Printer.CheckErr(fmt.Errorf("unable to overwrite \"plugins-dir\" flag: %w", err))
+					o.Printer.CheckErr(fmt.Errorf("unable to overwrite \"%s\" flag: %w", FlagPluginsFilesDir, err))
 				}
 			}
-			// Check if directory exists and is writable
+
+			// Check if directory exists and is writable.
 			if err := utils.ExistsAndIsWritable(f.Value.String()); err != nil {
-				o.Printer.CheckErr(fmt.Errorf("plugins-dir: %w", err))
+				o.Printer.CheckErr(fmt.Errorf("%s: %w", FlagPluginsFilesDir, err))
 			}
 
 			// Override "allowed-types" flag with viper config if not set by user.
-			f = cmd.Flags().Lookup("allowed-types")
+			f = cmd.Flags().Lookup(FlagAllowedTypes)
 			if f == nil {
 				// should never happen
-				o.Printer.CheckErr(fmt.Errorf("unable to retrieve flag allowed-types"))
+				o.Printer.CheckErr(fmt.Errorf("unable to retrieve flag %s", FlagAllowedTypes))
 			} else if !f.Changed && viper.IsSet(config.ArtifactAllowedTypesKey) {
 				val, err := config.ArtifactAllowedTypes()
 				if err != nil {
 					o.Printer.CheckErr(err)
 				}
 				if err := cmd.Flags().Set(f.Name, val.String()); err != nil {
-					o.Printer.CheckErr(fmt.Errorf("unable to overwrite \"allowed-types\" flag: %w", err))
+					o.Printer.CheckErr(fmt.Errorf("unable to overwrite \"%s\" flag: %w", FlagAllowedTypes, err))
 				}
 			}
 
-			f = cmd.Flags().Lookup("resolve-deps")
+			f = cmd.Flags().Lookup(FlagResolveDeps)
 			if f == nil {
 				// should never happen
-				o.Printer.CheckErr(fmt.Errorf("unable to retrieve flag resolve-deps"))
+				o.Printer.CheckErr(fmt.Errorf("unable to retrieve flag %s", FlagResolveDeps))
 			} else if !f.Changed && viper.IsSet(config.ArtifactInstallResolveDepsKey) {
 				val := viper.Get(config.ArtifactInstallResolveDepsKey)
 				if err := cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val)); err != nil {
-					o.Printer.CheckErr(fmt.Errorf("unable to overwrite \"resolve-deps\" flag: %w", err))
+					o.Printer.CheckErr(fmt.Errorf("unable to overwrite \"%s\" flag: %w", FlagResolveDeps, err))
 				}
 			}
 		},
@@ -152,17 +156,17 @@ func NewArtifactInstallCmd(ctx context.Context, opt *options.CommonOptions) *cob
 	}
 
 	o.RegistryOptions.AddFlags(cmd)
-	cmd.Flags().StringVarP(&o.rulesfilesDir, "rulesfiles-dir", "", config.RulesfilesDir,
+	cmd.Flags().StringVarP(&o.rulesfilesDir, FlagRulesFilesDir, "", config.RulesfilesDir,
 		"directory where to install rules. Defaults to /etc/falco")
-	cmd.Flags().StringVarP(&o.pluginsDir, "plugins-dir", "", config.PluginsDir,
+	cmd.Flags().StringVarP(&o.pluginsDir, FlagPluginsFilesDir, "", config.PluginsDir,
 		"directory where to install plugins. Defaults to /usr/share/falco/plugins")
-	cmd.Flags().Var(&o.allowedTypes, "allowed-types",
-		`list of artifact types that can be installed. If not specified or configured, all types are allowed.
+	cmd.Flags().Var(&o.allowedTypes, FlagAllowedTypes,
+		fmt.Sprintf(`list of artifact types that can be installed. If not specified or configured, all types are allowed.
 It accepts comma separated values or it can be repeated multiple times.
 Examples: 
-	--allowed-types="rulesfile,plugin"
-	--allowed-types=rulesfile --allowed-types=plugin`)
-	cmd.Flags().BoolVar(&o.resolveDeps, "resolve-deps", true,
+	--%s="rulesfile,plugin"
+	--%s=rulesfile --%s=plugin`, FlagAllowedTypes))
+	cmd.Flags().BoolVar(&o.resolveDeps, FlagResolveDeps, true,
 		"whether this command should resolve dependencies or not")
 
 	return cmd

--- a/cmd/artifact/install/install.go
+++ b/cmd/artifact/install/install.go
@@ -93,60 +93,60 @@ func NewArtifactInstallCmd(ctx context.Context, opt *options.CommonOptions) *cob
 			f := cmd.Flags().Lookup(FlagRulesFilesDir)
 			if f == nil {
 				// should never happen
-				o.Printer.CheckErr(fmt.Errorf("unable to retrieve flag %s", FlagRulesFilesDir))
+				o.Printer.CheckErr(fmt.Errorf("unable to retrieve flag %q", FlagRulesFilesDir))
 			} else if !f.Changed && viper.IsSet(config.ArtifactInstallRulesfilesDirKey) {
 
 				val := viper.Get(config.ArtifactInstallRulesfilesDirKey)
 				if err := cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val)); err != nil {
-					o.Printer.CheckErr(fmt.Errorf("unable to overwrite \"%s\" flag: %w", FlagRulesFilesDir, err))
+					o.Printer.CheckErr(fmt.Errorf("unable to overwrite %q flag: %w", FlagRulesFilesDir, err))
 				}
 			}
 
 			// Check if directory exists and is writable.
 			if err := utils.ExistsAndIsWritable(f.Value.String()); err != nil {
-				o.Printer.CheckErr(fmt.Errorf("%s: %w", FlagRulesFilesDir, err))
+				o.Printer.CheckErr(fmt.Errorf("%q: %w", FlagRulesFilesDir, err))
 			}
 
 			// Override "plugins-dir" flag with viper config if not set by user.
 			f = cmd.Flags().Lookup(FlagPluginsFilesDir)
 			if f == nil {
 				// should never happen
-				o.Printer.CheckErr(fmt.Errorf("unable to retrieve flag %s", FlagPluginsFilesDir))
+				o.Printer.CheckErr(fmt.Errorf("unable to retrieve flag %q", FlagPluginsFilesDir))
 			} else if !f.Changed && viper.IsSet(config.ArtifactInstallPluginsDirKey) {
 				val := viper.Get(config.ArtifactInstallPluginsDirKey)
 				if err := cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val)); err != nil {
-					o.Printer.CheckErr(fmt.Errorf("unable to overwrite \"%s\" flag: %w", FlagPluginsFilesDir, err))
+					o.Printer.CheckErr(fmt.Errorf("unable to overwrite %q flag: %w", FlagPluginsFilesDir, err))
 				}
 			}
 
 			// Check if directory exists and is writable.
 			if err := utils.ExistsAndIsWritable(f.Value.String()); err != nil {
-				o.Printer.CheckErr(fmt.Errorf("%s: %w", FlagPluginsFilesDir, err))
+				o.Printer.CheckErr(fmt.Errorf("%q: %w", FlagPluginsFilesDir, err))
 			}
 
 			// Override "allowed-types" flag with viper config if not set by user.
 			f = cmd.Flags().Lookup(FlagAllowedTypes)
 			if f == nil {
 				// should never happen
-				o.Printer.CheckErr(fmt.Errorf("unable to retrieve flag %s", FlagAllowedTypes))
+				o.Printer.CheckErr(fmt.Errorf("unable to retrieve flag %q", FlagAllowedTypes))
 			} else if !f.Changed && viper.IsSet(config.ArtifactAllowedTypesKey) {
 				val, err := config.ArtifactAllowedTypes()
 				if err != nil {
 					o.Printer.CheckErr(err)
 				}
 				if err := cmd.Flags().Set(f.Name, val.String()); err != nil {
-					o.Printer.CheckErr(fmt.Errorf("unable to overwrite \"%s\" flag: %w", FlagAllowedTypes, err))
+					o.Printer.CheckErr(fmt.Errorf("unable to overwrite %s flag: %w", FlagAllowedTypes, err))
 				}
 			}
 
 			f = cmd.Flags().Lookup(FlagResolveDeps)
 			if f == nil {
 				// should never happen
-				o.Printer.CheckErr(fmt.Errorf("unable to retrieve flag %s", FlagResolveDeps))
+				o.Printer.CheckErr(fmt.Errorf("unable to retrieve flag %q", FlagResolveDeps))
 			} else if !f.Changed && viper.IsSet(config.ArtifactInstallResolveDepsKey) {
 				val := viper.Get(config.ArtifactInstallResolveDepsKey)
 				if err := cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val)); err != nil {
-					o.Printer.CheckErr(fmt.Errorf("unable to overwrite \"%s\" flag: %w", FlagResolveDeps, err))
+					o.Printer.CheckErr(fmt.Errorf("unable to overwrite %q flag: %w", FlagResolveDeps, err))
 				}
 			}
 		},


### PR DESCRIPTION
**What type of PR is this?**

This PR adds a tiny refactoring and cleanup on `artifact install` and `artifact follow` commands.
In details, adds sharing of flag names as constants between packages and cleans up unneeded commands' description.

/kind cleanup

**Any specific area of the project related to this PR?**

/area cli

**What this PR does / why we need it**:

To remove duplicated code and improve maintainability.
To cleanup commands' documentation.

**Which issue(s) this PR fixes**:

NA

**Special notes for your reviewer**:

NA
