### PR TITLE
fix(cmd/registry): login to registry before running pull/push cmds

### DIFF
--- a/cmd/registry/auth/basic/basic.go
+++ b/cmd/registry/auth/basic/basic.go
@@ -56,8 +56,6 @@ func NewBasicCmd(ctx context.Context, opt *options.CommonOptions) *cobra.Command
 		Long:                  "Login to an OCI registry to push and pull artifacts",
 		Args:                  cobra.MaximumNArgs(1),
 		PreRun: func(cmd *cobra.Command, args []string) {
-			opt.Initialize()
-			opt.Printer.CheckErr(config.Load(opt.ConfigFile))
 			o.Printer.CheckErr(o.Validate(args))
 		},
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/registry/auth/oauth/oauth.go
+++ b/cmd/registry/auth/oauth/oauth.go
@@ -58,10 +58,6 @@ func NewOauthCmd(ctx context.Context, opt *options.CommonOptions) *cobra.Command
 		Short:                 "Retrieve access and refresh tokens for OAuth2.0 client credentials flow authentication",
 		Long:                  longOauth,
 		Args:                  cobra.ExactArgs(1),
-		PreRun: func(cmd *cobra.Command, args []string) {
-			opt.Initialize()
-			opt.Printer.CheckErr(config.Load(opt.ConfigFile))
-		},
 		Run: func(cmd *cobra.Command, args []string) {
 			o.Printer.CheckErr(o.RunOauth(ctx, args))
 		},

--- a/cmd/registry/pull/pull.go
+++ b/cmd/registry/pull/pull.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/falcosecurity/falcoctl/internal/config"
+	"github.com/falcosecurity/falcoctl/internal/login"
 	"github.com/falcosecurity/falcoctl/internal/utils"
 	"github.com/falcosecurity/falcoctl/pkg/options"
 )
@@ -78,6 +80,16 @@ func NewPullCmd(ctx context.Context, opt *options.CommonOptions) *cobra.Command 
 		Args:                  cobra.ExactArgs(1),
 		PreRun: func(cmd *cobra.Command, args []string) {
 			o.Printer.CheckErr(o.Validate())
+
+			// Perform authentications using basic auth.
+			basicAuths, err := config.BasicAuths()
+			opt.Printer.CheckErr(err)
+			opt.Printer.CheckErr(login.PerformBasicAuthsLogin(ctx, basicAuths))
+
+			// Perform authentications using oauth auth.
+			oauthAuths, err := config.OauthAuths()
+			opt.Printer.CheckErr(err)
+			opt.Printer.CheckErr(login.PerformOauthAuths(ctx, o.CommonOptions, oauthAuths))
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			o.Printer.CheckErr(o.RunPull(ctx, args))

--- a/cmd/registry/pull/pull.go
+++ b/cmd/registry/pull/pull.go
@@ -77,14 +77,13 @@ func NewPullCmd(ctx context.Context, opt *options.CommonOptions) *cobra.Command 
 		Long:                  longPull,
 		Args:                  cobra.ExactArgs(1),
 		PreRun: func(cmd *cobra.Command, args []string) {
-			o.Initialize()
 			o.Printer.CheckErr(o.Validate())
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			o.Printer.CheckErr(o.RunPull(ctx, args))
 		},
 	}
-	o.CommonOptions.AddFlags(cmd.Flags())
+
 	o.RegistryOptions.AddFlags(cmd)
 	o.Printer.CheckErr(o.ArtifactOptions.AddFlags(cmd))
 	cmd.Flags().StringVarP(&o.destDir, "dest-dir", "o", "", "destination dir where to save the artifacts(default: current directory)")

--- a/cmd/registry/push/push.go
+++ b/cmd/registry/push/push.go
@@ -17,7 +17,6 @@ package push
 import (
 	"context"
 	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"github.com/falcosecurity/falcoctl/internal/utils"
@@ -87,14 +86,12 @@ func NewPushCmd(ctx context.Context, opt *options.CommonOptions) *cobra.Command 
 		Args:                  cobra.MinimumNArgs(2),
 		SilenceErrors:         false,
 		PreRun: func(cmd *cobra.Command, args []string) {
-			o.Initialize()
 			o.Printer.CheckErr(o.validate())
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			o.Printer.CheckErr(o.RunPush(ctx, args))
 		},
 	}
-	o.CommonOptions.AddFlags(cmd.Flags())
 	o.RegistryOptions.AddFlags(cmd)
 	o.Printer.CheckErr(o.ArtifactOptions.AddFlags(cmd))
 

--- a/cmd/registry/push/push.go
+++ b/cmd/registry/push/push.go
@@ -17,8 +17,11 @@ package push
 import (
 	"context"
 	"fmt"
+
 	"github.com/spf13/cobra"
 
+	"github.com/falcosecurity/falcoctl/internal/config"
+	"github.com/falcosecurity/falcoctl/internal/login"
 	"github.com/falcosecurity/falcoctl/internal/utils"
 	"github.com/falcosecurity/falcoctl/pkg/oci"
 	ocipusher "github.com/falcosecurity/falcoctl/pkg/oci/pusher"
@@ -87,6 +90,16 @@ func NewPushCmd(ctx context.Context, opt *options.CommonOptions) *cobra.Command 
 		SilenceErrors:         false,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			o.Printer.CheckErr(o.validate())
+
+			// Perform authentications using basic auth.
+			basicAuths, err := config.BasicAuths()
+			opt.Printer.CheckErr(err)
+			opt.Printer.CheckErr(login.PerformBasicAuthsLogin(ctx, basicAuths))
+
+			// Perform authentications using oauth auth.
+			oauthAuths, err := config.OauthAuths()
+			opt.Printer.CheckErr(err)
+			opt.Printer.CheckErr(login.PerformOauthAuths(ctx, o.CommonOptions, oauthAuths))
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			o.Printer.CheckErr(o.RunPush(ctx, args))

--- a/cmd/registry/registry.go
+++ b/cmd/registry/registry.go
@@ -16,13 +16,13 @@ package registry
 
 import (
 	"context"
-	"github.com/falcosecurity/falcoctl/internal/config"
 
 	"github.com/spf13/cobra"
 
 	"github.com/falcosecurity/falcoctl/cmd/registry/auth"
 	"github.com/falcosecurity/falcoctl/cmd/registry/pull"
 	"github.com/falcosecurity/falcoctl/cmd/registry/push"
+	"github.com/falcosecurity/falcoctl/internal/config"
 	commonoptions "github.com/falcosecurity/falcoctl/pkg/options"
 )
 

--- a/cmd/registry/registry.go
+++ b/cmd/registry/registry.go
@@ -16,6 +16,7 @@ package registry
 
 import (
 	"context"
+	"github.com/falcosecurity/falcoctl/internal/config"
 
 	"github.com/spf13/cobra"
 
@@ -32,6 +33,10 @@ func NewRegistryCmd(ctx context.Context, opt *commonoptions.CommonOptions) *cobr
 		DisableFlagsInUseLine: true,
 		Short:                 "Interact with OCI registries",
 		Long:                  "Interact with OCI registries",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			// Load configuration from ENV variables and/or config file.
+			opt.Printer.CheckErr(config.Load(opt.ConfigFile))
+		},
 	}
 
 	cmd.AddCommand(auth.NewAuthCmd(ctx, opt))

--- a/internal/login/doc.go
+++ b/internal/login/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2023 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package login defines helpers functions used to login to OCI registries using
+// different authentication mechanisms.
+package login

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -1,0 +1,61 @@
+// Copyright 2023 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package login
+
+import (
+	"context"
+
+	"golang.org/x/oauth2/clientcredentials"
+	"oras.land/oras-go/v2/registry/remote/auth"
+
+	"github.com/falcosecurity/falcoctl/cmd/registry/auth/basic"
+	"github.com/falcosecurity/falcoctl/cmd/registry/auth/oauth"
+	"github.com/falcosecurity/falcoctl/internal/config"
+	"github.com/falcosecurity/falcoctl/pkg/options"
+)
+
+// PerformBasicAuthsLogin logins to the registries and stores the credentials in a local store.
+func PerformBasicAuthsLogin(ctx context.Context, auths []config.BasicAuth) error {
+	for _, basicAuth := range auths {
+		cred := &auth.Credential{
+			Username: basicAuth.User,
+			Password: basicAuth.Password,
+		}
+		if err := basic.DoLogin(ctx, basicAuth.Registry, cred); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// PerformOauthAuths logins to the registries and store the credentials in a  local store.
+func PerformOauthAuths(ctx context.Context, opt *options.CommonOptions, auths []config.OauthAuth) error {
+	for _, auth := range auths {
+		oauthMgr := oauth.RegistryOauthOptions{
+			CommonOptions: opt,
+			Conf: clientcredentials.Config{
+				ClientID:     auth.ClientID,
+				ClientSecret: auth.ClientSecret,
+				TokenURL:     auth.TokenURL,
+			},
+		}
+		if err := oauthMgr.RunOauth(ctx, []string{auth.Registry}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

`falcoctl registry pull/push` commands do not parse `ENV` variables and `config file` for credential values. In order to `pull/push` artifacts to private registries we need to explicitly run `falcoctl registry auth` command. This PR allows for credentials to be passed directly to `pull/push` commands using `ENV` variable and/or `config file`.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
