### PR TITLE
fix(cmd/artifact): authenticate only for subcommands that require it

### DIFF
--- a/cmd/artifact/artifact.go
+++ b/cmd/artifact/artifact.go
@@ -64,20 +64,27 @@ func NewArtifactCmd(ctx context.Context, opt *commonoptions.CommonOptions) *cobr
 			// Save the index cache for later use by the sub commands.
 			opt.Initialize(commonoptions.WithIndexCache(indexCache))
 
-			// Perform authentication using basic auth.
-			if basicAuths, err = config.BasicAuths(); err != nil {
-				return err
-			}
-			if err = login.PerformBasicAuthsLogin(ctx, basicAuths); err != nil {
-				return err
+			// Authenticate for commands that requires it.
+			if cmd.CalledAs() != list.CommandName && cmd.CalledAs() != search.CommandName {
+				// Perform authentication using basic auth.
+				if basicAuths, err = config.BasicAuths(); err != nil {
+					return err
+				}
+				if err = login.PerformBasicAuthsLogin(ctx, basicAuths); err != nil {
+					return err
+				}
+
+				// Perform authentications using oauth auth.
+				if oauthAuths, err = config.OauthAuths(); err != nil {
+					return err
+				}
+
+				if err = login.PerformOauthAuths(ctx, opt, oauthAuths); err != nil {
+					return err
+				}
 			}
 
-			// Perform authentications using oauth auth.
-			if oauthAuths, err = config.OauthAuths(); err != nil {
-				return err
-			}
-
-			return login.PerformOauthAuths(ctx, opt, oauthAuths)
+			return nil
 		},
 	}
 

--- a/cmd/artifact/list/artifact_list.go
+++ b/cmd/artifact/list/artifact_list.go
@@ -16,6 +16,7 @@ package list
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -23,6 +24,9 @@ import (
 	"github.com/falcosecurity/falcoctl/pkg/options"
 	"github.com/falcosecurity/falcoctl/pkg/output"
 )
+
+// CommandName name of the command. It has to be the first word in the use line.
+const CommandName = "list"
 
 type artifactListOptions struct {
 	*options.CommonOptions
@@ -37,7 +41,7 @@ func NewArtifactListCmd(ctx context.Context, opt *options.CommonOptions) *cobra.
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "list [flags]",
+		Use:                   fmt.Sprintf("%s [flags]", CommandName),
 		DisableFlagsInUseLine: true,
 		Short:                 "List all artifacts",
 		Long:                  "List all artifacts",

--- a/cmd/artifact/search/artifact_search.go
+++ b/cmd/artifact/search/artifact_search.go
@@ -58,6 +58,7 @@ func NewArtifactSearchCmd(ctx context.Context, opt *options.CommonOptions) *cobr
 		Long:                  "Search an artifact by keywords",
 		Args:                  cobra.MinimumNArgs(1),
 		SilenceErrors:         true,
+		SilenceUsage:          true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return o.Validate()
 		},

--- a/cmd/artifact/search/artifact_search.go
+++ b/cmd/artifact/search/artifact_search.go
@@ -27,6 +27,8 @@ import (
 
 const (
 	defaultMinScore = 0.65
+	// CommandName name of the command. It has to be the first word in the use line.
+	CommandName = "search"
 )
 
 type artifactSearchOptions struct {
@@ -50,7 +52,7 @@ func NewArtifactSearchCmd(ctx context.Context, opt *options.CommonOptions) *cobr
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "search [keyword1 [keyword2 ...]] [flags]",
+		Use:                   fmt.Sprintf("%s [keyword1 [keyword2 ...]] [flags]", CommandName),
 		DisableFlagsInUseLine: true,
 		Short:                 "Search an artifact by keywords",
 		Long:                  "Search an artifact by keywords",


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:
The artifact command registers a preRun function that authenticates the configured registries in the configuration file. But not all the subcommands need authentication. This PR prevent the authentication logic to run for subcommands that do not require it.

Furthermore, it prevents `artifact search` from printing the usage in case of errors.
**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #281 

**Special notes for your reviewer**:
