### PR TITLE
update(ci): only sign releases

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -21,11 +21,6 @@ on:
         description: The digest of the pushed image.
         value: ${{ jobs.docker-image.outputs.digest }}
 
-permissions:
-  contents: read
-  packages: write
-  id-token: write # needed for signing the images with GitHub OIDC Token
-
 jobs:
   docker-image:
     runs-on: ubuntu-22.04

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -21,6 +21,11 @@ on:
         description: The digest of the pushed image.
         value: ${{ jobs.docker-image.outputs.digest }}
 
+permissions:
+  contents: read
+  packages: write
+  id-token: write # needed for signing the images with GitHub OIDC Token
+
 jobs:
   docker-image:
     runs-on: ubuntu-22.04

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -89,6 +89,5 @@ jobs:
         env:
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
           TAGS: ${{ steps.meta_falcoctl.outputs.tags }}
-          COSIGN_EXPERIMENTAL: "true"
           COSIGN_YES: "true"
         run: echo "${TAGS}" | xargs -I {} cosign sign {}@${DIGEST}

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -85,7 +85,7 @@ jobs:
           cosign-release: 'v2.0.2'
 
       - name: Sign the images with GitHub OIDC Token
-        if: inputs.sign
+        if: ${{ inputs.sign }}
         env:
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
           TAGS: ${{ steps.meta_falcoctl.outputs.tags }}

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -79,10 +79,8 @@ jobs:
             BUILD_DATE=${{ inputs.build_date }}
 
       - name: Install Cosign
-        if: inputs.sign
-        uses: sigstore/cosign-installer@03d0fecf172873164a163bbc64bed0f3bf114ed7 # v3.4.0
-        with:
-          cosign-release: 'v2.0.2'
+        if: ${{ inputs.sign }}
+        uses: sigstore/cosign-installer@dd6b2e2b610a11fd73dd187a43d57cc1394e35f9 # v3.0.5
 
       - name: Sign the images with GitHub OIDC Token
         if: ${{ inputs.sign }}

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -12,6 +12,10 @@ on:
       build_date:
         required: true
         type: string
+      sign:
+        required: false
+        default: false
+        type: boolean
     outputs:
       digest:
         description: The digest of the pushed image.
@@ -42,11 +46,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_SECRET }}
       
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@03d0fecf172873164a163bbc64bed0f3bf114ed7 # v3.4.0
-        with:
-          cosign-release: 'v2.0.2'
-
       - name: Docker Meta
         id: meta_falcoctl
         uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96 # v4.3.0
@@ -73,9 +72,18 @@ jobs:
             RELEASE=${{ inputs.release }}
             COMMIT=${{ inputs.commit }}
             BUILD_DATE=${{ inputs.build_date }}
-      
+
+      - name: Install Cosign
+        if: inputs.sign
+        uses: sigstore/cosign-installer@03d0fecf172873164a163bbc64bed0f3bf114ed7 # v3.4.0
+        with:
+          cosign-release: 'v2.0.2'
+
       - name: Sign the images with GitHub OIDC Token
+        if: inputs.sign
         env:
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
           TAGS: ${{ steps.meta_falcoctl.outputs.tags }}
-        run: echo "${TAGS}" | xargs -I {} cosign sign -y {}@${DIGEST}
+          COSIGN_EXPERIMENTAL: "true"
+          COSIGN_YES: "true"
+        run: echo "${TAGS}" | xargs -I {} cosign sign {}@${DIGEST}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -118,6 +118,7 @@ jobs:
       release: ${{ needs.docker-configure.outputs.release }}
       commit: ${{ needs.docker-configure.outputs.commit }}
       build_date: ${{ needs.docker-configure.outputs.build_date }}
+      sign: true
 
   provenance-for-images:
     needs: [docker-configure, docker-image]


### PR DESCRIPTION

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area tests

**What this PR does / why we need it**:

This updates the CI/CD process so that:
1. only container images for releases are signed (and not main)
2. uses the env variable `COSIGN_YES` for cosign 2.0

cc @developer-guy 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
