### PR TITLE
fix(cmd): use arm64 instead of aarch64 in usage examples

### DIFF
--- a/cmd/push_test.go
+++ b/cmd/push_test.go
@@ -60,13 +60,13 @@ var registryPushHelp = `Push Falco "rulesfile" or "plugin" OCI artifacts to remo
 Example - Push artifact "myplugin.tar.gz" of type "plugin" for the platform where falcoctl is running (default):
 	falcoctl registry push --type plugin --version "1.2.3" localhost:5000/myplugin:latest myplugin.tar.gz
 
-Example - Push artifact "myplugin.tar.gz" of type "plugin" for platform "linux/aarch64":
-	falcoctl registry push --type plugin --version "1.2.3" localhost:5000/myplugin:latest myplugin.tar.gz --platform linux/aarch64
+Example - Push artifact "myplugin.tar.gz" of type "plugin" for platform "linux/arm64":
+	falcoctl registry push --type plugin --version "1.2.3" localhost:5000/myplugin:latest myplugin.tar.gz --platform linux/arm64
 
 Example - Push artifact "myplugin.tar.gz" of type "plugin" for multiple platforms:
 	falcoctl registry push --type plugin --version "1.2.3" localhost:5000/myplugin:latest \
 		myplugin-linux-x86_64.tar.gz --platform linux/x86_64 \
-		myplugin-linux-arm64.tar.gz --platform linux/aarch64
+		myplugin-linux-arm64.tar.gz --platform linux/arm64
 
 Example - Push artifact "myrulesfile.tar.gz" of type "rulesfile":
 	falcoctl registry push --type rulesfile --version "0.1.2" localhost:5000/myrulesfile:latest myrulesfile.tar.gz

--- a/cmd/registry/pull/pull.go
+++ b/cmd/registry/pull/pull.go
@@ -43,11 +43,11 @@ in the indexes.
 Example - Pull artifact "myplugin" for the platform where falcoctl is running (default) in the current working directory (default):
 	falcoctl registry pull localhost:5000/myplugin:latest
 
-Example - Pull artifact "myplugin" for platform "linux/aarch64" in the current working directory (default):
-	falcoctl registry pull localhost:5000/myplugin:latest --platform linux/aarch64
+Example - Pull artifact "myplugin" for platform "linux/arm64" in the current working directory (default):
+	falcoctl registry pull localhost:5000/myplugin:latest --platform linux/arm64
 
-Example - Pull artifact "myplugin" for platform "linux/aarch64" in "myDir" directory:
-	falcoctl registry pull localhost:5000/myplugin:latest --platform linux/aarch64 --dest-dir=./myDir
+Example - Pull artifact "myplugin" for platform "linux/arm64" in "myDir" directory:
+	falcoctl registry pull localhost:5000/myplugin:latest --platform linux/arm64 --dest-dir=./myDir
 
 Example - Pull artifact "myrulesfile":
 	falcoctl registry pull localhost:5000/myrulesfile:latest

--- a/cmd/registry/push/push.go
+++ b/cmd/registry/push/push.go
@@ -38,13 +38,13 @@ const (
 Example - Push artifact "myplugin.tar.gz" of type "plugin" for the platform where falcoctl is running (default):
 	falcoctl registry push --type plugin --version "1.2.3" localhost:5000/myplugin:latest myplugin.tar.gz
 
-Example - Push artifact "myplugin.tar.gz" of type "plugin" for platform "linux/aarch64":
-	falcoctl registry push --type plugin --version "1.2.3" localhost:5000/myplugin:latest myplugin.tar.gz --platform linux/aarch64
+Example - Push artifact "myplugin.tar.gz" of type "plugin" for platform "linux/arm64":
+	falcoctl registry push --type plugin --version "1.2.3" localhost:5000/myplugin:latest myplugin.tar.gz --platform linux/arm64
 
 Example - Push artifact "myplugin.tar.gz" of type "plugin" for multiple platforms:
 	falcoctl registry push --type plugin --version "1.2.3" localhost:5000/myplugin:latest \
 		myplugin-linux-x86_64.tar.gz --platform linux/x86_64 \
-		myplugin-linux-arm64.tar.gz --platform linux/aarch64
+		myplugin-linux-arm64.tar.gz --platform linux/arm64
 
 Example - Push artifact "myrulesfile.tar.gz" of type "rulesfile":
 	falcoctl registry push --type rulesfile --version "0.1.2" localhost:5000/myrulesfile:latest myrulesfile.tar.gz

--- a/pkg/oci/pusher/pusher_suite_test.go
+++ b/pkg/oci/pusher/pusher_suite_test.go
@@ -35,7 +35,7 @@ var (
 	testPluginTarball   = "../../test/data/plugin.tar.gz"
 	testPluginPlatform1 = "linux/amd64"
 	testPluginPlatform2 = "windows/amd64"
-	testPluginPlatform3 = "linux/aarch64"
+	testPluginPlatform3 = "linux/arm64"
 	ctx                 = context.Background()
 )
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

/kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

> /area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

Use `arm64` as architecture for arm platforms instead of `aarch64` in command usages.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
