### PR TITLE
fix(cmd/registry/auth/basic): removed default oci registry

### DIFF
--- a/cmd/registry/auth/basic/basic.go
+++ b/cmd/registry/auth/basic/basic.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/falcosecurity/falcoctl/internal/config"
 	"github.com/falcosecurity/falcoctl/internal/utils"
-	"github.com/falcosecurity/falcoctl/pkg/oci"
 	"github.com/falcosecurity/falcoctl/pkg/oci/authn"
 	"github.com/falcosecurity/falcoctl/pkg/oci/registry"
 	"github.com/falcosecurity/falcoctl/pkg/options"
@@ -31,16 +30,6 @@ import (
 
 type loginOptions struct {
 	*options.CommonOptions
-	hostname string
-}
-
-func (o *loginOptions) Validate(args []string) error {
-	if len(args) != 0 {
-		o.hostname = args[0]
-	} else {
-		o.hostname = oci.DefaultRegistry
-	}
-	return nil
 }
 
 // NewBasicCmd returns the basic command.
@@ -54,12 +43,9 @@ func NewBasicCmd(ctx context.Context, opt *options.CommonOptions) *cobra.Command
 		DisableFlagsInUseLine: true,
 		Short:                 "Login to an OCI registry",
 		Long:                  "Login to an OCI registry to push and pull artifacts",
-		Args:                  cobra.MaximumNArgs(1),
+		Args:                  cobra.ExactArgs(1),
 		SilenceErrors:         true,
 		SilenceUsage:          true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return o.Validate(args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.RunBasic(ctx, args)
 		},
@@ -70,13 +56,7 @@ func NewBasicCmd(ctx context.Context, opt *options.CommonOptions) *cobra.Command
 
 // RunBasic executes the business logic for the basic command.
 func (o *loginOptions) RunBasic(ctx context.Context, args []string) error {
-	var reg string
-
-	if n := len(args); n == 1 {
-		reg = args[0]
-	} else {
-		reg = oci.DefaultRegistry
-	}
+	reg := args[0]
 
 	user, token, err := utils.GetCredentials(o.Printer)
 	if err != nil {

--- a/pkg/oci/constants.go
+++ b/pkg/oci/constants.go
@@ -28,9 +28,6 @@ const (
 	// FalcoPluginLayerMediaType is the MediaType for plugins.
 	FalcoPluginLayerMediaType = "application/vnd.cncf.falco.plugin.layer.v1+tar.gz"
 
-	// DefaultRegistry is the default container registry to use.
-	DefaultRegistry = "ghcr.io"
-
 	// DefaultTag is the default tag reference to be used when none is provided.
 	DefaultTag = "latest"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area cli

**What this PR does / why we need it**:

The `auth basic` command assumes `ghcr.io` as default oci registry when no hostname is specified. Given that `falcoctl` is a generic tool there is no good reason to keep this default value. 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
