### PR TITLE
fix(cmd/push): correctly push artifacts to ECR registry

### DIFF
--- a/pkg/oci/pusher/pusher.go
+++ b/pkg/oci/pusher/pusher.go
@@ -237,7 +237,17 @@ func (p *Pusher) storeConfigLayer(ctx context.Context, fileStore *file.Store,
 		artifactConfig = &oci.ArtifactConfig{}
 	}
 
-	return p.toFileStore(ctx, fileStore, layerMediaType, ConfigLayerName, artifactConfig)
+	cfgDesc, err := p.toFileStore(ctx, fileStore, layerMediaType, ConfigLayerName, artifactConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// Remove annotations added to descriptor by the filestore.Add operation.
+	// AWS ECR errors when annotations are set in the config descriptor.
+	// See: https://github.com/falcosecurity/falcoctl/issues/302
+	cfgDesc.Annotations = nil
+
+	return cfgDesc, nil
 }
 
 func (p *Pusher) storeArtifactsIndex(ctx context.Context, fileStore *file.Store,


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

It seems that ECR does not support annotations on the descriptor of the OCI image configuration. This fix consists in clearing the annotations map of the config descriptor when created. By default the filestore.Add method adds the "org.opencontainers.image.title" annotation.


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #
#302 
**Special notes for your reviewer**:
