### PR TITLE
fix(cmd): correctly propagate signal handler to sub-commands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,9 +16,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
-	"os/signal"
-	"syscall"
 
 	"github.com/spf13/cobra"
 
@@ -68,14 +65,6 @@ func New(ctx context.Context, opt *options.Common) *cobra.Command {
 
 // Execute configures the signal handlers and runs the command.
 func Execute(cmd *cobra.Command, printer *output.Printer) error {
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGKILL)
-
-	// If the ctx is marked as done then we reset the signals.
-	go func() {
-		<-ctx.Done()
-		fmt.Printf("\nreceived signal, terminating...\n")
-		stop()
-	}()
 	// we do not log the error here since we expect that each subcommand
 	// handles the errors by itself.
 	err := cmd.Execute()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

The context used to handle the signals is not propagated to the sub-commands. This makes `falcoctl` unresponsive to signals sent to it. This commit fixes this behavior by correctly passing the context that handles the signals.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
