### PR TITLE
add some log messages to inform user when generating the tls certificates

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,7 +65,6 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - depguard
     - dogsled
     - dupl
     - errcheck

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,7 +54,7 @@ func New(ctx context.Context, opt *options.Common) *cobra.Command {
 	opt.AddFlags(rootCmd.PersistentFlags())
 
 	// Commands
-	rootCmd.AddCommand(tls.NewTLSCmd())
+	rootCmd.AddCommand(tls.NewTLSCmd(opt))
 	rootCmd.AddCommand(version.NewVersionCmd(opt))
 	rootCmd.AddCommand(registry.NewRegistryCmd(ctx, opt))
 	rootCmd.AddCommand(index.NewIndexCmd(ctx, opt))

--- a/cmd/tls/install/install.go
+++ b/cmd/tls/install/install.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/falcosecurity/falcoctl/pkg/install/tls"
+	commonoptions "github.com/falcosecurity/falcoctl/pkg/options"
 )
 
 // Defaults.
@@ -30,8 +31,9 @@ const (
 )
 
 // NewTLSInstallCmd returns the tls install command.
-func NewTLSInstallCmd() *cobra.Command {
+func NewTLSInstallCmd(opt *commonoptions.Common) *cobra.Command {
 	options := tls.Options{}
+	options.Common = opt
 
 	cmd := &cobra.Command{
 		Use:                   "install",

--- a/cmd/tls/tls.go
+++ b/cmd/tls/tls.go
@@ -18,10 +18,11 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/falcosecurity/falcoctl/cmd/tls/install"
+	commonoptions "github.com/falcosecurity/falcoctl/pkg/options"
 )
 
 // NewTLSCmd return the tls command.
-func NewTLSCmd() *cobra.Command {
+func NewTLSCmd(opt *commonoptions.Common) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "tls",
 		TraverseChildren:      true,
@@ -30,7 +31,7 @@ func NewTLSCmd() *cobra.Command {
 		Long:                  `Generate and install TLS material for Falco`,
 	}
 
-	cmd.AddCommand(install.NewTLSInstallCmd())
+	cmd.AddCommand(install.NewTLSInstallCmd(opt))
 
 	return cmd
 }

--- a/pkg/install/tls/generator.go
+++ b/pkg/install/tls/generator.go
@@ -26,6 +26,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/falcosecurity/falcoctl/pkg/output"
 )
 
 // A GRPCTLS represents a TLS Generator for Falco.
@@ -239,7 +241,7 @@ func (g *GRPCTLS) GenerateClient(caTemplate *x509.Certificate, caKey DSAKey, not
 }
 
 // FlushToDisk is used to persist the cert material from a GRPCTLS to disk given a path.
-func (g *GRPCTLS) FlushToDisk(path string) error {
+func (g *GRPCTLS) FlushToDisk(path string, logger *output.Printer) error {
 	p, err := satisfyDir(path)
 	if err != nil {
 		return fmt.Errorf("invalid path: %w", err)
@@ -248,11 +250,13 @@ func (g *GRPCTLS) FlushToDisk(path string) error {
 
 	for _, name := range certsFilenames {
 		f := filepath.Join(path, name)
+		logger.Info.Printf("Saving %s to %s\n", name, path)
 		if err := os.WriteFile(f, g.certs[name].Bytes(), 0o600); err != nil {
 			return fmt.Errorf("unable to write %q: %w", name, err)
 		}
 	}
 
+	logger.Info.Println("Done generating the TLS certificates")
 	return nil
 }
 

--- a/pkg/install/tls/handler.go
+++ b/pkg/install/tls/handler.go
@@ -18,6 +18,8 @@ import (
 	"crypto/elliptic"
 	"fmt"
 	"os"
+
+	commonoptions "github.com/falcosecurity/falcoctl/pkg/options"
 )
 
 // Options represents the `install tls` command o.
@@ -31,6 +33,8 @@ type Options struct {
 	DNSSANs   []string
 	IPSANs    []string
 	Algorithm string
+
+	Common *commonoptions.Common
 }
 
 // Run executes the business logic of the `install tls` command.
@@ -43,6 +47,8 @@ func (o *Options) Run() error {
 		}
 		o.Path = cwd
 	}
+
+	o.Common.Printer.Info.Printf("Generating certificates in %s directory\n", o.Path)
 
 	keyGenerator := NewKeyGenerator(DSAType(o.Algorithm))
 
@@ -77,10 +83,5 @@ func (o *Options) Run() error {
 		return err
 	}
 
-	err = generator.FlushToDisk(o.Path)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return generator.FlushToDisk(o.Path, o.Common.Printer)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind feature


**Any specific area of the project related to this PR?**
/area cli


**What this PR does / why we need it**:

- add some log messages to inform user when generating the tls certificates
when using this command I felt lost in what was going on and did not see any outputs when the command succeed.

This PR add some logs just to inform the user what is going on

```
$ ./falcoctl tls install
INFO: Generating certificates in /Users/cpanato/code/src/github.com/falcosecurity/falcoctl directory
INFO: Saving server.key to /Users/cpanato/code/src/github.com/falcosecurity/falcoctl
INFO: Saving client.key to /Users/cpanato/code/src/github.com/falcosecurity/falcoctl
INFO: Saving ca.key to /Users/cpanato/code/src/github.com/falcosecurity/falcoctl
INFO: Saving ca.crt to /Users/cpanato/code/src/github.com/falcosecurity/falcoctl
INFO: Saving server.crt to /Users/cpanato/code/src/github.com/falcosecurity/falcoctl
INFO: Saving client.crt to /Users/cpanato/code/src/github.com/falcosecurity/falcoctl
INFO: Done generating the TLS certificates
```

/assign @maxgio92 @leogr 


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
