### PR TITLE
fix(cmd/artifact/follow): colored output despite `--disable-styling`

### DIFF
--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -234,6 +234,9 @@ func (p *Printer) DisableStylingf() {
 // EnableStyling enables styling globally for all existing printers.
 func (p *Printer) EnableStyling() {
 	pterm.EnableStyling()
+	if p.DisableStyling {
+		pterm.DisableColor()
+	}
 }
 
 // ExitOnErr aborts the execution in case of errors, and prints the error using the configured printer.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

Output of the `artifact follow` command still contains colors even when the `--disable-styling` flag is present.
This PR removes the colors but still maintains "styling", which consists here in prepending each line with the log level and the artifact path.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #295 

**Special notes for your reviewer**:

This is a simple fix for the color issue I observed and encountered, but the logic problem of the `--disable-styling` flag not respected remains.
I don't know if it is a problem or not.