### PR TITLE
fix(follower): do not cache authentication tokens

### DIFF
--- a/cmd/artifact/info/info.go
+++ b/cmd/artifact/info/info.go
@@ -62,7 +62,7 @@ func NewArtifactInfoCmd(ctx context.Context, opt *options.Common) *cobra.Command
 func (o *artifactInfoOptions) RunArtifactInfo(ctx context.Context, args []string) error {
 	var data [][]string
 
-	client, err := ociutils.Client()
+	client, err := ociutils.Client(true)
 	if err != nil {
 		return err
 	}

--- a/internal/follower/follower.go
+++ b/internal/follower/follower.go
@@ -101,7 +101,7 @@ func New(ref string, printer *output.Printer, conf *Config) (*Follower, error) {
 	}
 	tag := parsedRef.Reference
 
-	client, err := ociutils.Client()
+	client, err := ociutils.Client(false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oci/authn/client.go
+++ b/pkg/oci/authn/client.go
@@ -34,6 +34,7 @@ type Options struct {
 	CredentialsFuncsCache map[string]func(context.Context, string) (auth.Credential, error)
 	CredentialsFuncs      []func(context.Context, string) (auth.Credential, error)
 	AutoLoginHandler      *AutoLoginHandler
+	ClientTokenCache      auth.Cache
 }
 
 // NewClient creates a new authenticated client to interact with a remote registry.
@@ -62,7 +63,7 @@ func NewClient(options ...func(*Options)) *auth.Client {
 				// TODO(loresuso, alacuku): tls config.
 			},
 		},
-		Cache: auth.NewCache(),
+		Cache: opt.ClientTokenCache,
 		Credential: func(ctx context.Context, reg string) (auth.Credential, error) {
 			// try cred func from cache first
 			credFunc, exists := opt.CredentialsFuncsCache[reg]
@@ -141,5 +142,12 @@ func WithCredentials(cred *auth.Credential) func(c *Options) {
 func WithStore(store credentials.Store) func(c *Options) {
 	return func(c *Options) {
 		c.CredentialsFuncs = append(c.CredentialsFuncs, credentials.Credential(store))
+	}
+}
+
+// WithClientTokenCache adds a cache to the auth.Client used to store auth tokens.
+func WithClientTokenCache(cache auth.Cache) func(c *Options) {
+	return func(c *Options) {
+		c.ClientTokenCache = cache
 	}
 }

--- a/pkg/oci/authn/client.go
+++ b/pkg/oci/authn/client.go
@@ -91,8 +91,7 @@ func NewClient(options ...func(*Options)) *auth.Client {
 					return cred, nil
 				}
 			}
-			// remember empty cred func for registries we dont have creds for
-			opt.CredentialsFuncsCache[reg] = EmptyCredentialFunc
+
 			return auth.EmptyCredential, nil
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

## Token caching in the client
Avoid caching authentication tokens in the client since they can expire. In those cases the client cannot invalidate the expired token, hence it will not have permission to access the resources.
Each time the client will acquire a new token based on it's configuration. Remember that this change does not affect the underlying credential helper's cache.

## CredentialFuncs caching for repositories
When we create the http client for a given repository the code checks if it is somehow configured. It caches a function called `credentialFunction`. This function knows how to retrieve the credentials for a given repository. For unconfigured repositories, or repositories that fail to get valid credentials using their `credentialFunction,` we cache an `emptyCredential function`. This causes trouble in case of transient errors causing the client to not recover. This commit avoids caching the `emptyCredential function` in such cases or for unconfigured repositories.

Remember that the caching of `credentialFunctions` prevents falcoctl in follow mode to pick up new configurations for repositories that at startup time had a working configuration.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #325 

**Special notes for your reviewer**:
