### PR TITLE
update(output): complete rework of the output system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ test:
 .PHONY: gci
 gci:
 ifeq (, $(shell which gci))
-	@go install github.com/daixiang0/gci@v0.9.0
+	@go install github.com/daixiang0/gci@v0.11.1
 GCI=$(GOBIN)/gci
 else
 GCI=$(shell which gci)

--- a/cmd/artifact/info/info.go
+++ b/cmd/artifact/info/info.go
@@ -62,6 +62,7 @@ func NewArtifactInfoCmd(ctx context.Context, opt *options.Common) *cobra.Command
 
 func (o *artifactInfoOptions) RunArtifactInfo(ctx context.Context, args []string) error {
 	var data [][]string
+	logger := o.Printer.Logger
 
 	client, err := ociutils.Client(true)
 	if err != nil {
@@ -75,7 +76,7 @@ func (o *artifactInfoOptions) RunArtifactInfo(ctx context.Context, args []string
 		if err != nil {
 			entry, ok := o.IndexCache.MergedIndexes.EntryByName(name)
 			if !ok {
-				o.Printer.Warning.Printfln("cannot find %q, skipping", name)
+				logger.Warn("Cannot find artifact, skipping", logger.Args("name", name))
 				continue
 			}
 			ref = fmt.Sprintf("%s/%s", entry.Registry, entry.Repository)
@@ -93,7 +94,7 @@ func (o *artifactInfoOptions) RunArtifactInfo(ctx context.Context, args []string
 
 		tags, err := repo.Tags(ctx)
 		if err != nil && !errors.Is(err, context.Canceled) {
-			o.Printer.Warning.Printfln("cannot retrieve tags from t %q, %v", ref, err)
+			logger.Warn("Cannot retrieve tags from", logger.Args("ref", ref, "reason", err.Error()))
 			continue
 		} else if errors.Is(err, context.Canceled) {
 			// When the context is canceled we exit, since we receive a termination signal.

--- a/cmd/artifact/install/install_suite_test.go
+++ b/cmd/artifact/install/install_suite_test.go
@@ -71,7 +71,6 @@ var _ = BeforeSuite(func() {
 	// Create and configure the common options.
 	opt = commonoptions.NewOptions()
 	opt.Initialize(commonoptions.WithWriter(output))
-	opt.Printer.DisableStylingf()
 
 	// Create the oras registry.
 	orasRegistry, err = testutils.NewOrasRegistry(registry, true)
@@ -98,5 +97,5 @@ var _ = AfterSuite(func() {
 func executeRoot(args []string) error {
 	rootCmd.SetArgs(args)
 	rootCmd.SetOut(output)
-	return cmd.Execute(rootCmd, opt.Printer)
+	return cmd.Execute(rootCmd, opt)
 }

--- a/cmd/artifact/install/install_test.go
+++ b/cmd/artifact/install/install_test.go
@@ -51,8 +51,8 @@ Flags:
 
 Global Flags:
       --config string     config file to be used for falcoctl (default "/etc/falcoctl/falcoctl.yaml")
-      --disable-styling   Disable output styling such as spinners, progress bars and colors. Styling is automatically disabled if not attacched to a tty (default false)
-  -v, --verbose           Enable verbose logs (default false)
+      --log-format string   Set formatting for logs (color, text, json) (default "color")
+      --log-level string    Set level for logs (info, warn, debug, trace) (default "info")
 
 `
 
@@ -170,7 +170,7 @@ var artifactInstallTests = Describe("install", func() {
 				args = []string{artifactCmd, installCmd, "--config", configFile}
 			})
 			installAssertFailedBehavior(artifactInstallUsage,
-				"ERRO: no artifacts to install, please configure artifacts or pass them as arguments to this command")
+				"ERROR no artifacts to install, please configure artifacts or pass them as arguments to this command")
 		})
 
 		When("unreachable registry", func() {
@@ -181,7 +181,7 @@ var artifactInstallTests = Describe("install", func() {
 				Expect(err).To(BeNil())
 				args = []string{artifactCmd, installCmd, "noregistry/testrules", "--plain-http", "--config", configFile}
 			})
-			installAssertFailedBehavior(artifactInstallUsage, `ERRO: unable to fetch reference`)
+			installAssertFailedBehavior(artifactInstallUsage, `ERROR unable to fetch reference`)
 		})
 
 		When("invalid repository", func() {
@@ -193,7 +193,7 @@ var artifactInstallTests = Describe("install", func() {
 				Expect(err).To(BeNil())
 				args = []string{artifactCmd, installCmd, newReg, "--plain-http", "--config", configFile}
 			})
-			installAssertFailedBehavior(artifactInstallUsage, fmt.Sprintf("ERRO: unable to fetch reference %q", newReg))
+			installAssertFailedBehavior(artifactInstallUsage, fmt.Sprintf("ERROR unable to fetch reference %q", newReg))
 		})
 
 		When("with disallowed types (rulesfile)", func() {
@@ -222,7 +222,7 @@ var artifactInstallTests = Describe("install", func() {
 					"--config", configFilePath, "--allowed-types", "rulesfile"}
 			})
 
-			installAssertFailedBehavior(artifactInstallUsage, "ERRO: cannot download artifact of type \"plugin\": type not permitted")
+			installAssertFailedBehavior(artifactInstallUsage, "ERROR cannot download artifact of type \"plugin\": type not permitted")
 		})
 
 		When("with disallowed types (plugin)", func() {
@@ -251,7 +251,7 @@ var artifactInstallTests = Describe("install", func() {
 					"--config", configFilePath, "--allowed-types", "plugin"}
 			})
 
-			installAssertFailedBehavior(artifactInstallUsage, "ERRO: cannot download artifact of type \"rulesfile\": type not permitted")
+			installAssertFailedBehavior(artifactInstallUsage, "ERROR cannot download artifact of type \"rulesfile\": type not permitted")
 		})
 
 		When("an unknown type is used", func() {
@@ -281,7 +281,7 @@ var artifactInstallTests = Describe("install", func() {
 					"--config", configFilePath, "--allowed-types", "plugin," + wrongType}
 			})
 
-			installAssertFailedBehavior(artifactInstallUsage, fmt.Sprintf("ERRO: invalid argument \"plugin,%s\" for \"--allowed-types\" flag: "+
+			installAssertFailedBehavior(artifactInstallUsage, fmt.Sprintf("ERROR invalid argument \"plugin,%s\" for \"--allowed-types\" flag: "+
 				"not valid token %q: must be one of \"rulesfile\", \"plugin\"", wrongType, wrongType))
 		})
 
@@ -315,7 +315,7 @@ var artifactInstallTests = Describe("install", func() {
 			})
 
 			It("check that fails and the usage is not printed", func() {
-				expectedError := fmt.Sprintf("ERRO: cannot use directory %q "+
+				expectedError := fmt.Sprintf("ERROR cannot use directory %q "+
 					"as install destination: %s is not writable", destDir, destDir)
 				Expect(err).To(HaveOccurred())
 				Expect(output).ShouldNot(gbytes.Say(regexp.QuoteMeta(artifactInstallUsage)))
@@ -353,7 +353,7 @@ var artifactInstallTests = Describe("install", func() {
 			})
 
 			It("check that fails and the usage is not printed", func() {
-				expectedError := fmt.Sprintf("ERRO: cannot use directory %q "+
+				expectedError := fmt.Sprintf("ERROR cannot use directory %q "+
 					"as install destination: %s doesn't exists", destDir, destDir)
 				Expect(err).To(HaveOccurred())
 				Expect(output).ShouldNot(gbytes.Say(regexp.QuoteMeta(artifactInstallUsage)))
@@ -391,7 +391,7 @@ var artifactInstallTests = Describe("install", func() {
 			})
 
 			It("check that fails and the usage is not printed", func() {
-				expectedError := fmt.Sprintf("ERRO: cannot use directory %q "+
+				expectedError := fmt.Sprintf("ERROR cannot use directory %q "+
 					"as install destination: %s is not writable", destDir, destDir)
 				Expect(err).To(HaveOccurred())
 				Expect(output).ShouldNot(gbytes.Say(regexp.QuoteMeta(artifactInstallUsage)))
@@ -429,7 +429,7 @@ var artifactInstallTests = Describe("install", func() {
 			})
 
 			It("check that fails and the usage is not printed", func() {
-				expectedError := fmt.Sprintf("ERRO: cannot use directory %q "+
+				expectedError := fmt.Sprintf("ERROR cannot use directory %q "+
 					"as install destination: %s doesn't exists", destDir, destDir)
 				Expect(err).To(HaveOccurred())
 				Expect(output).ShouldNot(gbytes.Say(regexp.QuoteMeta(artifactInstallUsage)))

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -75,7 +75,7 @@ var tests = []testCase{
 
 func run(t *testing.T, test *testCase) {
 	// Setup
-	c := New(context.Background(), &options.Common{})
+	c := New(context.Background(), options.NewOptions())
 	o := bytes.NewBufferString("")
 	c.SetOut(o)
 	c.SetErr(o)

--- a/cmd/index/add/add_suite_test.go
+++ b/cmd/index/add/add_suite_test.go
@@ -67,7 +67,6 @@ var _ = BeforeSuite(func() {
 	// Create and configure the common options.
 	opt = commonoptions.NewOptions()
 	opt.Initialize(commonoptions.WithWriter(output))
-	opt.Printer.DisableStylingf()
 
 	// Create temporary directory used to save the configuration file.
 	configFile, err = testutils.CreateEmptyFile("falcoctl.yaml")
@@ -84,5 +83,5 @@ var _ = AfterSuite(func() {
 func executeRoot(args []string) error {
 	rootCmd.SetArgs(args)
 	rootCmd.SetOut(output)
-	return cmd.Execute(rootCmd, opt.Printer)
+	return cmd.Execute(rootCmd, opt)
 }

--- a/cmd/index/add/add_test.go
+++ b/cmd/index/add/add_test.go
@@ -33,9 +33,9 @@ Flags:
 -h, --help   help for add
 
 Global Flags:
-	--config string     config file to be used for falcoctl (default "/etc/falcoctl/falcoctl.yaml")
-	--disable-styling   Disable output styling such as spinners, progress bars and colors. Styling is automatically disabled if not attacched to a tty (default false)
--v, --verbose           Enable verbose logs (default false)
+      --config string       config file to be used for falcoctl (default "/etc/falcoctl/falcoctl.yaml")
+      --log-format string   Set formatting for logs (color, text, json) (default "color")
+      --log-level string    Set level for logs (info, warn, debug, trace) (default "info")
 `
 
 //nolint:lll // no need to check for line length.
@@ -48,9 +48,9 @@ Flags:
   -h, --help   help for add
 
 Global Flags:
-      --config string     config file to be used for falcoctl (default "/etc/falcoctl/falcoctl.yaml")
-      --disable-styling   Disable output styling such as spinners, progress bars and colors. Styling is automatically disabled if not attacched to a tty (default false)
-  -v, --verbose           Enable verbose logs (default false)
+      --config string       config file to be used for falcoctl (default "/etc/falcoctl/falcoctl.yaml")
+      --log-format string   Set formatting for logs (color, text, json) (default "color")
+      --log-level string    Set level for logs (info, warn, debug, trace) (default "info")
 `
 
 var addAssertFailedBehavior = func(usage, specificError string) {
@@ -97,14 +97,14 @@ var indexAddTests = Describe("add", func() {
 			BeforeEach(func() {
 				args = []string{indexCmd, addCmd, "--config", configFile, indexName}
 			})
-			addAssertFailedBehavior(indexAddUsage, "ERRO: accepts between 2 and 3 arg(s), received 1")
+			addAssertFailedBehavior(indexAddUsage, "ERROR accepts between 2 and 3 arg(s), received 1")
 		})
 
 		When("with invalid URL", func() {
 			BeforeEach(func() {
 				args = []string{indexCmd, addCmd, "--config", configFile, indexName, "NOTAPROTOCAL://something"}
 			})
-			addAssertFailedBehavior(indexAddUsage, "ERRO: unable to add index: unable to fetch index \"testName\""+
+			addAssertFailedBehavior(indexAddUsage, "ERROR unable to add index: unable to fetch index \"testName\""+
 				" with URL \"NOTAPROTOCAL://something\": unable to fetch index: cannot fetch index: Get "+
 				"\"notaprotocal://something\": unsupported protocol scheme \"notaprotocal\"")
 		})
@@ -113,7 +113,7 @@ var indexAddTests = Describe("add", func() {
 			BeforeEach(func() {
 				args = []string{indexCmd, addCmd, "--config", configFile, indexName, "http://noindex", "notabackend"}
 			})
-			addAssertFailedBehavior(indexAddUsage, "ERRO: unable to add index: unable to fetch index \"testName\" "+
+			addAssertFailedBehavior(indexAddUsage, "ERROR unable to add index: unable to fetch index \"testName\" "+
 				"with URL \"http://noindex\": unsupported index backend type: notabackend")
 		})
 	})

--- a/cmd/index/remove/remove.go
+++ b/cmd/index/remove/remove.go
@@ -54,30 +54,32 @@ func NewIndexRemoveCmd(ctx context.Context, opt *options.Common) *cobra.Command 
 }
 
 func (o *indexRemoveOptions) RunIndexRemove(ctx context.Context, args []string) error {
-	o.Printer.Verbosef("Creating in-memory cache using indexes file %q and indexes directory %q", config.IndexesFile, config.IndexesDir)
+	logger := o.Printer.Logger
+
+	logger.Debug("Creating in-memory cache using", logger.Args("indexes file", config.IndexesFile, "indexes directory", config.IndexesDir))
 	indexCache, err := cache.New(ctx, config.IndexesFile, config.IndexesDir)
 	if err != nil {
 		return fmt.Errorf("unable to create index cache: %w", err)
 	}
 
 	for _, name := range args {
-		o.Printer.Info.Printfln("Removing index %q", name)
+		logger.Info("Removing index", logger.Args("name", name))
 		if err = indexCache.Remove(name); err != nil {
 			return fmt.Errorf("unable to remove index: %w", err)
 		}
 	}
 
-	o.Printer.Verbosef("Writing cache to disk")
+	logger.Debug("Writing cache to disk")
 	if _, err = indexCache.Write(); err != nil {
 		return fmt.Errorf("unable to write cache to disk: %w", err)
 	}
 
-	o.Printer.Verbosef("Removing indexes entries from configuration file %q", o.ConfigFile)
+	logger.Debug("Removing indexes entries from configuration", logger.Args("file", o.ConfigFile))
 	if err = config.RemoveIndexes(args, o.ConfigFile); err != nil {
 		return err
 	}
 
-	o.Printer.Success.Printfln("Indexes successfully removed")
+	logger.Info("Indexes successfully removed")
 
 	return nil
 }

--- a/cmd/index/update/update.go
+++ b/cmd/index/update/update.go
@@ -52,25 +52,27 @@ func NewIndexUpdateCmd(ctx context.Context, opt *options.Common) *cobra.Command 
 }
 
 func (o *indexUpdateOptions) RunIndexUpdate(ctx context.Context, args []string) error {
-	o.Printer.Verbosef("Creating in-memory cache using indexes file %q and indexes directory %q", config.IndexesFile, config.IndexesDir)
+	logger := o.Printer.Logger
+
+	logger.Debug("Creating in-memory cache using", logger.Args("indexes file", config.IndexesFile, "indexes directory", config.IndexesDir))
 	indexCache, err := cache.New(ctx, config.IndexesFile, config.IndexesDir)
 	if err != nil {
 		return fmt.Errorf("unable to create index cache: %w", err)
 	}
 
 	for _, arg := range args {
-		o.Printer.Info.Printfln("Updating index %q", arg)
+		logger.Info("Updating index file", logger.Args("name", arg))
 		if err := indexCache.Update(ctx, arg); err != nil {
 			return fmt.Errorf("an error occurred while updating index %q: %w", arg, err)
 		}
 	}
 
-	o.Printer.Verbosef("Writing cache to disk")
+	logger.Debug("Writing cache to disk")
 	if _, err = indexCache.Write(); err != nil {
 		return fmt.Errorf("unable to write cache to disk: %w", err)
 	}
 
-	o.Printer.Success.Printfln("Indexes successfully updated")
+	logger.Info("Indexes successfully updated")
 
 	return nil
 }

--- a/cmd/registry/auth/basic/basic.go
+++ b/cmd/registry/auth/basic/basic.go
@@ -58,7 +58,7 @@ func NewBasicCmd(ctx context.Context, opt *options.Common) *cobra.Command {
 // RunBasic executes the business logic for the basic command.
 func (o *loginOptions) RunBasic(ctx context.Context, args []string) error {
 	reg := args[0]
-
+	logger := o.Printer.Logger
 	user, token, err := utils.GetCredentials(o.Printer)
 	if err != nil {
 		return err
@@ -78,8 +78,8 @@ func (o *loginOptions) RunBasic(ctx context.Context, args []string) error {
 	if err := basic.Login(ctx, client, credentialStore, reg, user, token); err != nil {
 		return err
 	}
-	o.Printer.Verbosef("credentials added to credential store")
-	o.Printer.Success.Println("Login succeeded")
+	logger.Debug("Credentials added", logger.Args("credential store", config.RegistryCredentialConfPath()))
+	logger.Info("Login succeeded", logger.Args("registry", reg, "user", user))
 
 	return nil
 }

--- a/cmd/registry/auth/basic/basic_suite_test.go
+++ b/cmd/registry/auth/basic/basic_suite_test.go
@@ -102,7 +102,6 @@ var _ = BeforeSuite(func() {
 	// Create and configure the common options.
 	opt = commonoptions.NewOptions()
 	opt.Initialize(commonoptions.WithWriter(output))
-	opt.Printer.DisableStylingf()
 
 	// Start the local registry.
 	go func() {
@@ -131,5 +130,5 @@ var _ = AfterSuite(func() {
 func executeRoot(args []string) error {
 	rootCmd.SetArgs(args)
 	rootCmd.SetOut(output)
-	return cmd.Execute(rootCmd, opt.Printer)
+	return cmd.Execute(rootCmd, opt)
 }

--- a/cmd/registry/auth/basic/basic_test.go
+++ b/cmd/registry/auth/basic/basic_test.go
@@ -107,32 +107,8 @@ var registryAuthBasicTests = Describe("auth", func() {
 				args = []string{registryCmd, authCmd, basicCmd}
 			})
 			registryAuthBasicAssertFailedBehavior(registryAuthBasicUsage,
-				"ERRO: accepts 1 arg(s), received 0")
+				"ERROR accepts 1 arg(s), received 0")
 		})
-
-		/*
-					When("wrong credentials", func() {
-						BeforeEach(func() {
-
-							ptyFile, ttyFile, err := pty.Open()
-							Expect(err).To(BeNil())
-
-							os.Stdin = ttyFile
-							input := `username1
-			password1
-			`
-							_, err = ptyFile.Write([]byte(input))
-							Expect(err).To(BeNil())
-
-							http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-
-							args = []string{registryCmd, authCmd, basicCmd, "--config", configFile, registryBasic}
-						})
-
-						registryAuthBasicAssertFailedBehavior(registryAuthBasicUsage,
-							"ERRO: accepts 0 arg(s), received 0")
-					})
-		*/
 	})
 
 })

--- a/cmd/registry/auth/gcp/gcp.go
+++ b/cmd/registry/auth/gcp/gcp.go
@@ -66,20 +66,21 @@ func NewGcpCmd(ctx context.Context, opt *options.Common) *cobra.Command {
 // RunGcp executes the business logic for the gcp command.
 func (o *RegistryGcpOptions) RunGcp(ctx context.Context, args []string) error {
 	var err error
+	logger := o.Printer.Logger
 	reg := args[0]
 	if err = gcp.Login(ctx, reg); err != nil {
 		return err
 	}
-	o.Printer.Success.Printfln("GCP authentication successful for %q", reg)
+	logger.Info("GCP authentication successful", logger.Args("registry", reg))
 
-	o.Printer.Verbosef("Adding new gcp entry to configuration file %q", o.ConfigFile)
+	logger.Debug("Adding new gcp entry to configuration", logger.Args("file", o.ConfigFile))
 	if err = config.AddGcp([]config.GcpAuth{{
 		Registry: reg,
 	}}, o.ConfigFile); err != nil {
 		return fmt.Errorf("index entry %q: %w", reg, err)
 	}
 
-	o.Printer.Success.Printfln("GCP authentication entry for %q successfully added in configuration file", reg)
+	logger.Info("GCG authentication entry successfully added", logger.Args("registry", reg, "confgi file", o.ConfigFile))
 
 	return nil
 }

--- a/cmd/registry/auth/oauth/oauth.go
+++ b/cmd/registry/auth/oauth/oauth.go
@@ -17,6 +17,7 @@ package oauth
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2/clientcredentials"
@@ -24,6 +25,7 @@ import (
 	"github.com/falcosecurity/falcoctl/internal/config"
 	"github.com/falcosecurity/falcoctl/internal/login/oauth"
 	"github.com/falcosecurity/falcoctl/pkg/options"
+	"github.com/falcosecurity/falcoctl/pkg/output"
 )
 
 const (
@@ -67,17 +69,15 @@ func NewOauthCmd(ctx context.Context, opt *options.Common) *cobra.Command {
 
 	cmd.Flags().StringVar(&o.Conf.TokenURL, "token-url", "", "token URL used to get access and refresh tokens")
 	if err := cmd.MarkFlagRequired("token-url"); err != nil {
-		o.Printer.Error.Println("unable to mark flag \"token-url\" as required")
-		return nil
+		output.ExitOnErr(o.Printer, fmt.Errorf("unable to mark flag \"token-url\" as required"))
 	}
 	cmd.Flags().StringVar(&o.Conf.ClientID, "client-id", "", "client ID of the OAuth2.0 app")
 	if err := cmd.MarkFlagRequired("client-id"); err != nil {
-		o.Printer.Error.Println("unable to mark flag \"client-id\" as required")
-		return nil
+		output.ExitOnErr(o.Printer, fmt.Errorf("unable to mark flag \"client-id\" as required"))
 	}
 	cmd.Flags().StringVar(&o.Conf.ClientSecret, "client-secret", "", "client secret of the OAuth2.0 app")
 	if err := cmd.MarkFlagRequired("client-secret"); err != nil {
-		o.Printer.Error.Println("unable to mark flag \"client-secret\" as required")
+		output.ExitOnErr(o.Printer, fmt.Errorf("unable to mark flag \"client-secret\" as required"))
 		return nil
 	}
 	cmd.Flags().StringSliceVar(&o.Conf.Scopes, "scopes", nil, "comma separeted list of scopes for which requesting access")
@@ -91,6 +91,6 @@ func (o *RegistryOauthOptions) RunOAuth(ctx context.Context, args []string) erro
 	if err := oauth.Login(ctx, reg, &o.Conf); err != nil {
 		return err
 	}
-	o.Printer.Success.Printfln("client credentials correctly saved in %q", config.ClientCredentialsFile)
+	o.Printer.Logger.Info("Client credentials correctly saved", o.Printer.Logger.Args("file", config.ClientCredentialsFile))
 	return nil
 }

--- a/cmd/registry/auth/oauth/oauth_suite_test.go
+++ b/cmd/registry/auth/oauth/oauth_suite_test.go
@@ -84,7 +84,6 @@ var _ = BeforeSuite(func() {
 	// Create and configure the common options.
 	opt = commonoptions.NewOptions()
 	opt.Initialize(commonoptions.WithWriter(output))
-	opt.Printer.DisableStylingf()
 
 	// Create the oras registry.
 	orasRegistry, err = testutils.NewOrasRegistry(registry, true)
@@ -115,5 +114,5 @@ var _ = AfterSuite(func() {
 func executeRoot(args []string) error {
 	rootCmd.SetArgs(args)
 	rootCmd.SetOut(output)
-	return cmd.Execute(rootCmd, opt.Printer)
+	return cmd.Execute(rootCmd, opt)
 }

--- a/cmd/registry/auth/oauth/oauth_test.go
+++ b/cmd/registry/auth/oauth/oauth_test.go
@@ -65,8 +65,9 @@ Flags:
 
 Global Flags:
       --config string     config file to be used for falcoctl (default "/etc/falcoctl/falcoctl.yaml")
-      --disable-styling   Disable output styling such as spinners, progress bars and colors. Styling is automatically disabled if not attacched to a tty (default false)
-  -v, --verbose           Enable verbose logs (default false)
+      --log-format string   Set formatting for logs (color, text, json) (default "color")
+      --log-level string    Set level for logs (info, warn, debug, trace) (default "info")
+
 `
 
 //nolint:unused // false positive
@@ -132,7 +133,7 @@ var registryAuthOAuthTests = Describe("auth", func() {
 				args = []string{registryCmd, authCmd, oauthCmd}
 			})
 			registryAuthOAuthAssertFailedBehavior(registryAuthOAuthUsage,
-				"ERRO: accepts 1 arg(s), received 0")
+				"ERROR accepts 1 arg(s), received 0")
 		})
 
 		When("wrong client id", func() {
@@ -152,7 +153,7 @@ var registryAuthOAuthTests = Describe("auth", func() {
 				}
 			})
 			registryAuthOAuthAssertFailedBehavior(registryAuthOAuthUsage,
-				`ERRO: wrong client credentials, unable to retrieve token`)
+				`ERROR wrong client credentials, unable to retrieve token`)
 		})
 
 		When("wrong client secret", func() {
@@ -172,7 +173,7 @@ var registryAuthOAuthTests = Describe("auth", func() {
 				}
 			})
 			registryAuthOAuthAssertFailedBehavior(registryAuthOAuthUsage,
-				`ERRO: wrong client credentials, unable to retrieve token`)
+				`ERROR wrong client credentials, unable to retrieve token`)
 		})
 	})
 
@@ -199,7 +200,7 @@ var registryAuthOAuthTests = Describe("auth", func() {
 
 			It("should successed", func() {
 				Expect(output).Should(gbytes.Say(regexp.QuoteMeta(
-					`INFO: client credentials correctly saved in`)))
+					`INFO  Client credentials correctly saved`)))
 			})
 		})
 

--- a/cmd/registry/pull/pull.go
+++ b/cmd/registry/pull/pull.go
@@ -88,6 +88,7 @@ func NewPullCmd(ctx context.Context, opt *options.Common) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			o.Common.Initialize()
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -103,6 +104,7 @@ func NewPullCmd(ctx context.Context, opt *options.Common) *cobra.Command {
 
 // RunPull executes the business logic for the pull command.
 func (o *pullOptions) RunPull(ctx context.Context, args []string) error {
+	logger := o.Printer.Logger
 	ref := args[0]
 
 	registry, err := utils.GetRegistryFromRef(ref)
@@ -120,12 +122,12 @@ func (o *pullOptions) RunPull(ctx context.Context, args []string) error {
 		return err
 	}
 
-	o.Printer.Info.Printfln("Preparing to pull artifact %q", args[0])
+	logger.Info("Preparing to pull artifact", logger.Args("name", args[0]))
 
 	if o.destDir == "" {
-		o.Printer.Info.Printfln("Pulling artifact in the current directory")
+		logger.Info("Pulling artifact in the current directory")
 	} else {
-		o.Printer.Info.Printfln("Pulling artifact in %q directory", o.destDir)
+		logger.Info("Pulling artifact in", logger.Args("directory", o.destDir))
 	}
 
 	os, arch := runtime.GOOS, runtime.GOARCH
@@ -138,7 +140,7 @@ func (o *pullOptions) RunPull(ctx context.Context, args []string) error {
 		return err
 	}
 
-	o.Printer.Success.Printfln("Artifact of type %q pulled. Digest: %q", res.Type, res.Digest)
+	logger.Info("Artifact pulled", logger.Args("name", args[0], "type", res.Type, "digest", res.Digest))
 
 	return nil
 }

--- a/cmd/registry/pull/pull_suite_test.go
+++ b/cmd/registry/pull/pull_suite_test.go
@@ -70,7 +70,6 @@ var _ = BeforeSuite(func() {
 	// Create and configure the common options.
 	opt = commonoptions.NewOptions()
 	opt.Initialize(commonoptions.WithWriter(output))
-	opt.Printer.DisableStylingf()
 
 	// Create the oras registry.
 	orasRegistry, err = testutils.NewOrasRegistry(registry, true)
@@ -97,5 +96,5 @@ var _ = AfterSuite(func() {
 func executeRoot(args []string) error {
 	rootCmd.SetArgs(args)
 	rootCmd.SetOut(output)
-	return cmd.Execute(rootCmd, opt.Printer)
+	return cmd.Execute(rootCmd, opt)
 }

--- a/cmd/registry/pull/pull_test.go
+++ b/cmd/registry/pull/pull_test.go
@@ -144,7 +144,7 @@ var registryPullTests = Describe("pull", func() {
 			BeforeEach(func() {
 				args = []string{registryCmd, pullCmd}
 			})
-			pullAssertFailedBehavior(registryPullUsage, "ERRO: accepts 1 arg(s), received 0")
+			pullAssertFailedBehavior(registryPullUsage, "ERROR accepts 1 arg(s), received 0")
 		})
 
 		When("unreachable registry", func() {
@@ -155,7 +155,7 @@ var registryPullTests = Describe("pull", func() {
 				Expect(err).To(BeNil())
 				args = []string{registryCmd, pullCmd, "noregistry/testrules", "--plain-http", "--config", configFile}
 			})
-			pullAssertFailedBehavior(registryPullUsage, "ERRO: unable to connect to remote registry")
+			pullAssertFailedBehavior(registryPullUsage, "ERROR unable to connect to remote registry")
 		})
 
 		When("invalid repository", func() {
@@ -167,7 +167,7 @@ var registryPullTests = Describe("pull", func() {
 				Expect(err).To(BeNil())
 				args = []string{registryCmd, pullCmd, newReg, "--plain-http", "--config", configFile}
 			})
-			pullAssertFailedBehavior(registryPullUsage, fmt.Sprintf("ERRO: %s: not found", newReg))
+			pullAssertFailedBehavior(registryPullUsage, fmt.Sprintf("ERROR %s: not found", newReg))
 		})
 
 		When("unwritable --dest-dir", func() {
@@ -200,7 +200,7 @@ var registryPullTests = Describe("pull", func() {
 				artName := tmp[0]
 				tag := tmp[1]
 				expectedError := fmt.Sprintf(
-					"ERRO: unable to pull artifact generic-repo with %s tag from repo %s: failed to create file",
+					"ERROR unable to pull artifact generic-repo with %s tag from repo %s: failed to create file",
 					tag, artName)
 				Expect(err).To(HaveOccurred())
 				Expect(output).ShouldNot(gbytes.Say(regexp.QuoteMeta(registryPullUsage)))
@@ -233,10 +233,8 @@ var registryPullTests = Describe("pull", func() {
 			})
 
 			It("check that fails and the usage is not printed", func() {
-				expectedError := fmt.Sprintf(
-					"ERRO: unable to push artifact failed to ensure directories of the target path: mkdir %s: permission denied\n"+
-						"ERRO: unable to pull artifact %s with tag %s from repo %s: failed to ensure directories of the target path: mkdir %s: permission denied",
-					destDir, artifact, tag, artifact, destDir)
+				expectedError := fmt.Sprintf("ERROR unable to pull artifact %s with tag %s from repo %s: failed to ensure directories of the target path: "+
+					"mkdir %s: permission denied", artifact, tag, artifact, destDir)
 				Expect(err).To(HaveOccurred())
 				Expect(output).ShouldNot(gbytes.Say(regexp.QuoteMeta(registryPullUsage)))
 				Expect(output).Should(gbytes.Say(regexp.QuoteMeta(expectedError)))
@@ -264,7 +262,7 @@ var registryPullTests = Describe("pull", func() {
 			})
 
 			It("check that fails and the usage is not printed", func() {
-				expectedError := fmt.Sprintf("ERRO: %s: not found", registry+repo+"@"+wrongDigest)
+				expectedError := fmt.Sprintf("ERROR %s: not found", registry+repo+"@"+wrongDigest)
 				Expect(err).To(HaveOccurred())
 				Expect(output).ShouldNot(gbytes.Say(regexp.QuoteMeta(registryPullUsage)))
 				Expect(output).Should(gbytes.Say(regexp.QuoteMeta(expectedError)))
@@ -282,7 +280,7 @@ var registryPullTests = Describe("pull", func() {
 			})
 
 			It("check that fails and the usage is not printed", func() {
-				expectedError := fmt.Sprintf("ERRO: cannot extract registry name from ref %q", ref)
+				expectedError := fmt.Sprintf("ERROR cannot extract registry name from ref %q", ref)
 				Expect(err).To(HaveOccurred())
 				Expect(output).ShouldNot(gbytes.Say(regexp.QuoteMeta(registryPullUsage)))
 				Expect(output).Should(gbytes.Say(regexp.QuoteMeta(expectedError)))
@@ -298,7 +296,7 @@ var registryPullTests = Describe("pull", func() {
 				Expect(err).To(BeNil())
 				args = []string{registryCmd, pullCmd, newReg, "--plain-http", "--config", configFile}
 			})
-			pullAssertFailedBehavior(registryPullUsage, fmt.Sprintf("ERRO: unable to create new repository with ref %s: "+
+			pullAssertFailedBehavior(registryPullUsage, fmt.Sprintf("ERROR unable to create new repository with ref %s: "+
 				"invalid reference: invalid digest; invalid checksum digest format\n", newReg))
 		})
 

--- a/cmd/registry/push/push.go
+++ b/cmd/registry/push/push.go
@@ -124,6 +124,7 @@ func (o *pushOptions) runPush(ctx context.Context, args []string) error {
 	// When creating the tar.gz archives we need to remove them after we are done.
 	// We save the temporary dir where they live here.
 	var toBeDeleted string
+	logger := o.Printer.Logger
 
 	registry, err := utils.GetRegistryFromRef(ref)
 	if err != nil {
@@ -140,12 +141,12 @@ func (o *pushOptions) runPush(ctx context.Context, args []string) error {
 		return err
 	}
 
-	o.Printer.Info.Printfln("Preparing to push artifact %q of type %q", args[0], o.ArtifactType)
+	logger.Info("Preparing to push artifact", o.Printer.Logger.Args("name", args[0], "type", o.ArtifactType))
 
 	// Make sure to remove temporary working dir.
 	defer func() {
 		if err := os.RemoveAll(toBeDeleted); err != nil {
-			o.Printer.Warning.Printfln("Unable to remove temporary dir %q: %s", toBeDeleted, err.Error())
+			logger.Warn("Unable to remove temporary dir", logger.Args("name", toBeDeleted, "error", err.Error()))
 		}
 	}()
 
@@ -202,7 +203,7 @@ func (o *pushOptions) runPush(ctx context.Context, args []string) error {
 		return err
 	}
 
-	o.Printer.Success.Printfln("Artifact pushed. Digest: %q", res.Digest)
+	logger.Info("Artifact pushed", logger.Args("name", args[0], "type", res.Type, "digest", res.Digest))
 
 	return nil
 }

--- a/cmd/registry/push/push_suite_test.go
+++ b/cmd/registry/push/push_suite_test.go
@@ -71,7 +71,6 @@ var _ = BeforeSuite(func() {
 	// Create and configure the common options.
 	opt = commonoptions.NewOptions()
 	opt.Initialize(commonoptions.WithWriter(output))
-	opt.Printer.DisableStylingf()
 
 	// Create the oras registry.
 	orasRegistry, err = testutils.NewOrasRegistry(registry, true)
@@ -97,5 +96,5 @@ var _ = AfterSuite(func() {
 func executeRoot(args []string) error {
 	rootCmd.SetArgs(args)
 	rootCmd.SetOut(output)
-	return cmd.Execute(rootCmd, opt.Printer)
+	return cmd.Execute(rootCmd, opt)
 }

--- a/cmd/registry/registry.go
+++ b/cmd/registry/registry.go
@@ -36,6 +36,8 @@ func NewRegistryCmd(ctx context.Context, opt *commonoptions.Common) *cobra.Comma
 		Long:                  "Interact with OCI registries",
 		SilenceErrors:         true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// Initialize the options.
+			opt.Initialize()
 			// Load configuration from ENV variables and/or config file.
 			return config.Load(opt.ConfigFile)
 		},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,6 @@ import (
 	"github.com/falcosecurity/falcoctl/cmd/tls"
 	"github.com/falcosecurity/falcoctl/cmd/version"
 	"github.com/falcosecurity/falcoctl/pkg/options"
-	"github.com/falcosecurity/falcoctl/pkg/output"
 )
 
 const (
@@ -48,7 +47,14 @@ func New(ctx context.Context, opt *options.Common) *cobra.Command {
 		Use:               "falcoctl",
 		Short:             "The official CLI tool for working with Falco and its ecosystem components",
 		Long:              longRootCmd,
+		SilenceErrors:     true,
 		DisableAutoGenTag: true,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			// Initialize the common options for all subcommands.
+			// Subcommands con overwrite the default settings by calling initialize with
+			// different options.
+			opt.Initialize()
+		},
 	}
 
 	// Global flags
@@ -65,10 +71,10 @@ func New(ctx context.Context, opt *options.Common) *cobra.Command {
 }
 
 // Execute configures the signal handlers and runs the command.
-func Execute(cmd *cobra.Command, printer *output.Printer) error {
+func Execute(cmd *cobra.Command, opt *options.Common) error {
 	// we do not log the error here since we expect that each subcommand
 	// handles the errors by itself.
 	err := cmd.Execute()
-	printer.CheckErr(err)
+	opt.Printer.CheckErr(err)
 	return err
 }

--- a/cmd/testdata/help.txt
+++ b/cmd/testdata/help.txt
@@ -21,9 +21,9 @@ Available Commands:
   version     Print the falcoctl version information
 
 Flags:
-      --config string     config file to be used for falcoctl (default "/etc/falcoctl/falcoctl.yaml")
-      --disable-styling   Disable output styling such as spinners, progress bars and colors. Styling is automatically disabled if not attacched to a tty (default false)
-  -h, --help              help for falcoctl
-  -v, --verbose           Enable verbose logs (default false)
+      --config string       config file to be used for falcoctl (default "/etc/falcoctl/falcoctl.yaml")
+  -h, --help                help for falcoctl
+      --log-format string   Set formatting for logs (color, text, json) (default "color")
+      --log-level string    Set level for logs (info, warn, debug, trace) (default "info")
 
 Use "falcoctl [command] --help" for more information about a command.

--- a/cmd/testdata/noargsnoflags.txt
+++ b/cmd/testdata/noargsnoflags.txt
@@ -21,9 +21,9 @@ Available Commands:
   version     Print the falcoctl version information
 
 Flags:
-      --config string     config file to be used for falcoctl (default "/etc/falcoctl/falcoctl.yaml")
-      --disable-styling   Disable output styling such as spinners, progress bars and colors. Styling is automatically disabled if not attacched to a tty (default false)
-  -h, --help              help for falcoctl
-  -v, --verbose           Enable verbose logs (default false)
+      --config string       config file to be used for falcoctl (default "/etc/falcoctl/falcoctl.yaml")
+  -h, --help                help for falcoctl
+      --log-format string   Set formatting for logs (color, text, json) (default "color")
+      --log-level string    Set level for logs (info, warn, debug, trace) (default "info")
 
 Use "falcoctl [command] --help" for more information about a command.

--- a/cmd/testdata/wrongflag.txt
+++ b/cmd/testdata/wrongflag.txt
@@ -1,4 +1,3 @@
-Error: unknown flag: --wrong
 Usage:
   falcoctl [command]
 
@@ -12,10 +11,10 @@ Available Commands:
   version     Print the falcoctl version information
 
 Flags:
-      --config string     config file to be used for falcoctl (default "/etc/falcoctl/falcoctl.yaml")
-      --disable-styling   Disable output styling such as spinners, progress bars and colors. Styling is automatically disabled if not attacched to a tty (default false)
-  -h, --help              help for falcoctl
-  -v, --verbose           Enable verbose logs (default false)
+      --config string       config file to be used for falcoctl (default "/etc/falcoctl/falcoctl.yaml")
+  -h, --help                help for falcoctl
+      --log-format string   Set formatting for logs (color, text, json) (default "color")
+      --log-level string    Set level for logs (info, warn, debug, trace) (default "info")
 
 Use "falcoctl [command] --help" for more information about a command.
 

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -119,20 +119,17 @@ func (o *options) Run(v *version) error {
 	case yamlFormat:
 		marshaled, err := yaml.Marshal(v)
 		if err != nil {
-			o.Printer.Error.Println(err.Error())
 			return err
 		}
 		o.Printer.DefaultText.Printf("%s:\n%s\n", "Client Version", string(marshaled))
 	case jsonFormat:
 		marshaled, err := json.MarshalIndent(v, "", "   ")
 		if err != nil {
-			o.Printer.Error.Println(err.Error())
 			return err
 		}
 		o.Printer.DefaultText.Printf("%s:\n%s \n", "Client Version", string(marshaled))
 	default:
 		// We should never hit this case.
-		o.Printer.Error.Printf("options of the version command were not validated: --output=%q should have been rejected", o.Output)
 		return fmt.Errorf("options of the version command were not validated: --output=%q should have been rejected", o.Output)
 	}
 

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -150,7 +150,6 @@ var _ = Describe("Version", func() {
 			Context("run method", func() {
 				It("should print the error message", func() {
 					Expect(opt.Run(version)).Error().Should(HaveOccurred())
-					Expect(writer).Should(gbytes.Say("options of the version command were not validated"))
 				})
 			})
 		})

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/go-oauth2/oauth2/v4 v4.5.2
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/go-containerregistry v0.16.1
+	github.com/gookit/color v1.5.4
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/onsi/ginkgo/v2 v2.10.0
 	github.com/onsi/gomega v1.27.8
@@ -163,7 +164,6 @@ require (
 	github.com/google/uuid v1.3.1 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.5 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
-	github.com/gookit/color v1.5.4 // indirect
 	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect

--- a/internal/utils/credentials.go
+++ b/internal/utils/credentials.go
@@ -29,19 +29,17 @@ import (
 func GetCredentials(p *output.Printer) (username, password string, err error) {
 	reader := bufio.NewReader(os.Stdin)
 
-	p.DefaultText.Print("Username: ")
+	p.DefaultText.Print(p.FormatTitleAsLoggerInfo("Enter username:"))
 	username, err = reader.ReadString('\n')
 	if err != nil {
 		return "", "", err
 	}
 
-	p.DefaultText.Print("Password: ")
+	p.Logger.Info("Enter password: ")
 	bytePassword, err := term.ReadPassword(int(os.Stdin.Fd()))
 	if err != nil {
 		return "", "", err
 	}
-
-	p.DefaultText.Println()
 
 	password = string(bytePassword)
 	return strings.TrimSpace(username), strings.TrimSpace(password), nil

--- a/main.go
+++ b/main.go
@@ -36,7 +36,11 @@ func main() {
 	// If the ctx is marked as done then we reset the signals.
 	go func() {
 		<-ctx.Done()
-		opt.Printer.Info.Println("Received signal, terminating...")
+		// Stop all the printers if any is active
+		if opt.Printer != nil && opt.Printer.ProgressBar != nil && opt.Printer.ProgressBar.IsActive {
+			_, _ = opt.Printer.ProgressBar.Stop()
+		}
+		opt.Printer.Logger.Info("Received signal, terminating...")
 		stop()
 	}()
 
@@ -44,7 +48,7 @@ func main() {
 	rootCmd := cmd.New(ctx, opt)
 
 	// Execute the command.
-	if err := cmd.Execute(rootCmd, opt.Printer); err != nil {
+	if err := cmd.Execute(rootCmd, opt); err != nil {
 		os.Exit(1)
 	}
 	os.Exit(0)

--- a/pkg/install/tls/generator.go
+++ b/pkg/install/tls/generator.go
@@ -28,7 +28,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/falcosecurity/falcoctl/pkg/output"
+	"github.com/pterm/pterm"
 )
 
 // A GRPCTLS represents a TLS Generator for Falco.
@@ -242,7 +242,7 @@ func (g *GRPCTLS) GenerateClient(caTemplate *x509.Certificate, caKey DSAKey, not
 }
 
 // FlushToDisk is used to persist the cert material from a GRPCTLS to disk given a path.
-func (g *GRPCTLS) FlushToDisk(path string, logger *output.Printer) error {
+func (g *GRPCTLS) FlushToDisk(path string, logger *pterm.Logger) error {
 	p, err := satisfyDir(path)
 	if err != nil {
 		return fmt.Errorf("invalid path: %w", err)
@@ -251,13 +251,13 @@ func (g *GRPCTLS) FlushToDisk(path string, logger *output.Printer) error {
 
 	for _, name := range certsFilenames {
 		f := filepath.Join(path, name)
-		logger.Info.Printf("Saving %s to %s\n", name, path)
+		logger.Info("Saving file", logger.Args("name", name, "directory", path))
 		if err := os.WriteFile(f, g.certs[name].Bytes(), 0o600); err != nil {
 			return fmt.Errorf("unable to write %q: %w", name, err)
 		}
 	}
 
-	logger.Info.Println("Done generating the TLS certificates")
+	logger.Info("Done generating the TLS certificates")
 	return nil
 }
 

--- a/pkg/install/tls/handler.go
+++ b/pkg/install/tls/handler.go
@@ -40,6 +40,7 @@ type Options struct {
 
 // Run executes the business logic of the `install tls` command.
 func (o *Options) Run() error {
+	logger := o.Common.Printer.Logger
 	// If the output path is not given then get the current working directory.
 	if o.Path == "" {
 		cwd, err := os.Getwd()
@@ -49,7 +50,7 @@ func (o *Options) Run() error {
 		o.Path = cwd
 	}
 
-	o.Common.Printer.Info.Printf("Generating certificates in %s directory\n", o.Path)
+	logger.Info("Generating certificates", logger.Args("directory", o.Path))
 
 	keyGenerator := NewKeyGenerator(DSAType(o.Algorithm))
 
@@ -84,5 +85,5 @@ func (o *Options) Run() error {
 		return err
 	}
 
-	return generator.FlushToDisk(o.Path, o.Common.Printer)
+	return generator.FlushToDisk(o.Path, logger)
 }

--- a/pkg/options/common.go
+++ b/pkg/options/common.go
@@ -18,6 +18,7 @@ package options
 import (
 	"io"
 
+	"github.com/pterm/pterm"
 	"github.com/spf13/pflag"
 
 	"github.com/falcosecurity/falcoctl/internal/config"
@@ -31,36 +32,34 @@ import (
 type Common struct {
 	// Printer used by all commands to output messages.
 	Printer *output.Printer
-	// printerScope contains the data of the optional scope of a prefix.
-	// It used to add a prefix to the output of a printer.
-	printerScope string
 	// writer is used to write the output of the printer.
 	writer io.Writer
 	// Used to store the verbose flag, and then passed to the printer.
+	// Deprecated: will be removed in the future
 	verbose bool
 	// Disable the styling if set to true.
+	// Deprecated: will be removed in the future
 	disableStyling bool
 	// Config file. It must not be possible to be reinitialized by subcommands,
 	// using the Initialize function. It will be attached as global flags.
 	ConfigFile string
 	// IndexCache caches the entries for the configured indexes.
 	IndexCache *cache.Cache
+
+	logLevel  *LogLevel
+	logFormat *LogFormat
 }
 
 // NewOptions returns a new Common struct.
 func NewOptions() *Common {
-	return &Common{}
+	return &Common{
+		logLevel:  NewLogLevel(),
+		logFormat: NewLogFormat(),
+	}
 }
 
 // Configs type of the configs accepted by the Initialize function.
 type Configs func(options *Common)
-
-// WithPrinterScope sets the scope for the printer.
-func WithPrinterScope(scope string) Configs {
-	return func(options *Common) {
-		options.printerScope = scope
-	}
-}
 
 // WithWriter sets the writer for the printer.
 func WithWriter(writer io.Writer) Configs {
@@ -83,20 +82,35 @@ func (o *Common) Initialize(cfgs ...Configs) {
 		cfg(o)
 	}
 
-	// create the printer. The value of verbose is a flag value.
-	o.Printer = output.NewPrinter(o.printerScope, o.disableStyling, o.verbose, o.writer)
-}
+	// TODO(alacuku): remove once we remove the old flags
+	var logLevel pterm.LogLevel
+	if o.verbose {
+		logLevel = pterm.LogLevelDebug
+	} else {
+		logLevel = o.logLevel.ToPtermLogLevel()
+	}
 
-// IsVerbose used to check if the verbose flag is set or not.
-func (o *Common) IsVerbose() bool {
-	return o.verbose
+	var logFormatter pterm.LogFormatter
+	if o.disableStyling {
+		logFormatter = pterm.LogFormatterJSON
+	} else {
+		logFormatter = o.logFormat.ToPtermFormatter()
+	}
+
+	// create the printer. The value of verbose is a flag value.
+	o.Printer = output.NewPrinter(logLevel, logFormatter, o.writer)
 }
 
 // AddFlags registers the common flags.
 func (o *Common) AddFlags(flags *pflag.FlagSet) {
 	flags.BoolVarP(&o.verbose, "verbose", "v", false, "Enable verbose logs (default false)")
+	// Mark the verbose flag as deprecated.
+	_ = flags.MarkDeprecated("verbose", "please use --log-level")
 	flags.BoolVar(&o.disableStyling, "disable-styling", false, "Disable output styling such as spinners, progress bars and colors. "+
-		"Styling is automatically disabled if not attacched to a tty (default false)")
-	// Add global config
+		"Styling is automatically disabled if not attached to a tty (default false)")
+	// Mark the disableStyling as deprecated.
+	_ = flags.MarkDeprecated("disable-styling", "please use --log-format")
 	flags.StringVar(&o.ConfigFile, "config", config.ConfigPath, "config file to be used for falcoctl")
+	flags.Var(o.logFormat, "log-format", "Set formatting for logs (color, text, json)")
+	flags.Var(o.logLevel, "log-level", "Set level for logs (info, warn, debug, trace)")
 }

--- a/pkg/options/enum.go
+++ b/pkg/options/enum.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/exp/slices"
+)
+
+// Enum implements the flag interface. It can be used as a base for new flags that
+// can have a limited set of values.
+type Enum struct {
+	allowed []string
+	value   string
+}
+
+// NewEnum returns an enum struct. The firs argument is a set of values allowed for the flag.
+// The second argument is the default value of the flag.
+func NewEnum(allowed []string, d string) *Enum {
+	return &Enum{
+		allowed: allowed,
+		value:   d,
+	}
+}
+
+// String returns the value.
+func (e *Enum) String() string {
+	return e.value
+}
+
+// Set the value for the flag.
+func (e *Enum) Set(p string) error {
+	if !slices.Contains(e.allowed, p) {
+		return fmt.Errorf("invalid argument %q, please provide one of (%s)", p, strings.Join(e.allowed, ", "))
+	}
+	e.value = p
+	return nil
+}
+
+// Type returns the type of the flag.
+func (e *Enum) Type() string {
+	return "string"
+}

--- a/pkg/options/enum_test.go
+++ b/pkg/options/enum_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Enum", func() {
+	var (
+		allowed  = []string{"val1", "val2", "val3"}
+		defValue = "val1"
+		enum     *Enum
+	)
+
+	BeforeEach(func() {
+		enum = NewEnum(allowed, defValue)
+	})
+
+	JustAfterEach(func() {
+		enum = nil
+	})
+
+	Context("NewEnum Func", func() {
+		It("should return a not nil struct", func() {
+			Expect(enum).ShouldNot(BeNil())
+		})
+
+		It("should set the default values", func() {
+			Expect(enum.value).Should(Equal(defValue))
+		})
+
+		It("should set the allowed values", func() {
+			Expect(enum.allowed).Should(Equal(allowed))
+		})
+	})
+
+	Context("Set Func", func() {
+		var val string
+		var err error
+		newVal := "val2"
+		newValWrong := "WrongVal"
+
+		JustBeforeEach(func() {
+			err = enum.Set(val)
+		})
+
+		Context("Setting an allowed value", func() {
+			BeforeEach(func() {
+				val = newVal
+			})
+
+			It("Should set the correct val", func() {
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(enum.value).Should(Equal(newVal))
+			})
+		})
+
+		Context("Setting a not allowed value", func() {
+			BeforeEach(func() {
+				val = newValWrong
+			})
+
+			It("Should error", func() {
+				Expect(err).Should(HaveOccurred())
+			})
+		})
+	})
+
+	Context("String Func", func() {
+		It("Should return the setted value", func() {
+			Expect(enum.String()).Should(Equal(defValue))
+		})
+	})
+
+	Context("Type Func", func() {
+		It("Should return the string type", func() {
+			Expect(enum.Type()).Should(Equal("string"))
+		})
+	})
+
+})

--- a/pkg/options/logFormat.go
+++ b/pkg/options/logFormat.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import (
+	"github.com/pterm/pterm"
+)
+
+const (
+	// LogFormatColor formatting option for logs.
+	LogFormatColor = "color"
+	// LogFormatText formatting option for logs.
+	LogFormatText = "text"
+	// LogFormatJSON formatting otion for logs.
+	LogFormatJSON = "json"
+)
+
+var logFormats = []string{LogFormatColor, LogFormatText, LogFormatJSON}
+
+// LogFormat data structure for log-format flag.
+type LogFormat struct {
+	*Enum
+}
+
+// NewLogFormat returns a new Enum configured for the log formats flag.
+func NewLogFormat() *LogFormat {
+	return &LogFormat{
+		Enum: NewEnum(logFormats, LogFormatColor),
+	}
+}
+
+// ToPtermFormatter converts the current formatter to pterm.LogFormatter.
+func (lg *LogFormat) ToPtermFormatter() pterm.LogFormatter {
+	var formatter pterm.LogFormatter
+
+	switch lg.value {
+	case LogFormatColor:
+		formatter = pterm.LogFormatterColorful
+	case LogFormatText:
+		pterm.DisableColor()
+		formatter = pterm.LogFormatterColorful
+	case LogFormatJSON:
+		formatter = pterm.LogFormatterJSON
+	}
+	return formatter
+}

--- a/pkg/options/logFormat_test.go
+++ b/pkg/options/logFormat_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import (
+	"github.com/gookit/color"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pterm/pterm"
+)
+
+var _ = Describe("LogFormat", func() {
+	var (
+		logFormatter *LogFormat
+	)
+	BeforeEach(func() {
+		logFormatter = NewLogFormat()
+	})
+
+	Context("NewLogFormat Func", func() {
+		It("should return a new logFormatter", func() {
+			Expect(logFormatter).ShouldNot(BeNil())
+			Expect(logFormatter.value).Should(Equal(LogFormatColor))
+			Expect(logFormatter.allowed).Should(Equal(logFormats))
+		})
+	})
+
+	Context("ToPtermFormatter Func", func() {
+		var output pterm.LogFormatter
+
+		JustBeforeEach(func() {
+			output = logFormatter.ToPtermFormatter()
+		})
+
+		Context("Color", func() {
+			BeforeEach(func() {
+				Expect(logFormatter.Set(LogFormatColor)).ShouldNot(HaveOccurred())
+			})
+
+			It("should return the color logFormatter", func() {
+				Expect(output).Should(Equal(pterm.LogFormatterColorful))
+				Expect(pterm.PrintColor).Should(BeTrue())
+				Expect(color.Enable).Should(BeTrue())
+			})
+		})
+
+		Context("Text", func() {
+			BeforeEach(func() {
+				Expect(logFormatter.Set(LogFormatText)).ShouldNot(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				pterm.EnableColor()
+			})
+
+			It("should return the text logFormatter", func() {
+				Expect(output).Should(Equal(pterm.LogFormatterColorful))
+				Expect(pterm.PrintColor).Should(BeFalse())
+				Expect(color.Enable).Should(BeFalse())
+			})
+		})
+
+		Context("JSON", func() {
+			BeforeEach(func() {
+				Expect(logFormatter.Set(LogFormatJSON)).ShouldNot(HaveOccurred())
+			})
+
+			It("should return the json logFormatter", func() {
+				Expect(output).Should(Equal(pterm.LogFormatterJSON))
+				Expect(pterm.PrintColor).Should(BeTrue())
+				Expect(color.Enable).Should(BeTrue())
+			})
+		})
+	})
+})

--- a/pkg/options/logLevel.go
+++ b/pkg/options/logLevel.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import (
+	"github.com/pterm/pterm"
+)
+
+const (
+	// LogLevelInfo level option for logs.
+	LogLevelInfo = "info"
+	// LogLevelWarn level opiton for logs.
+	LogLevelWarn = "warn"
+	// LogLevelDebug level option for logs.
+	LogLevelDebug = "debug"
+	// LogLevelTrace level option for logs.
+	LogLevelTrace = "trace"
+)
+
+var logLevels = []string{LogLevelInfo, LogLevelWarn, LogLevelDebug, LogLevelTrace}
+
+// LogLevel data structure for log-level flag.
+type LogLevel struct {
+	*Enum
+}
+
+// NewLogLevel returns a new Enum configured for the log level flag.
+func NewLogLevel() *LogLevel {
+	return &LogLevel{
+		Enum: NewEnum(logLevels, LogLevelInfo),
+	}
+}
+
+// ToPtermLogLevel converts the current log level to pterm.LogLevel.
+func (ll *LogLevel) ToPtermLogLevel() pterm.LogLevel {
+	var level pterm.LogLevel
+	switch ll.value {
+	case LogLevelInfo:
+		level = pterm.LogLevelInfo
+	case LogLevelWarn:
+		level = pterm.LogLevelWarn
+	case LogLevelDebug:
+		level = pterm.LogLevelDebug
+	case LogLevelTrace:
+		level = pterm.LogLevelTrace
+	}
+	return level
+}

--- a/pkg/options/logLevel_test.go
+++ b/pkg/options/logLevel_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pterm/pterm"
+)
+
+var _ = Describe("LogLevel", func() {
+	var (
+		logLevel *LogLevel
+	)
+	BeforeEach(func() {
+		logLevel = NewLogLevel()
+	})
+
+	Context("NewLogLevel Func", func() {
+		It("should return a new LogLevel", func() {
+			Expect(logLevel).ShouldNot(BeNil())
+			Expect(logLevel.value).Should(Equal(LogLevelInfo))
+			Expect(logLevel.allowed).Should(Equal(logLevels))
+		})
+	})
+
+	Context("ToPtermLogLevel Func", func() {
+		var output pterm.LogLevel
+
+		JustBeforeEach(func() {
+			output = logLevel.ToPtermLogLevel()
+		})
+
+		Context("Info", func() {
+			BeforeEach(func() {
+				Expect(logLevel.Set(LogLevelInfo)).ShouldNot(HaveOccurred())
+			})
+
+			It("should return the Info level", func() {
+				Expect(output).Should(Equal(pterm.LogLevelInfo))
+			})
+		})
+
+		Context("Warn", func() {
+			BeforeEach(func() {
+				Expect(logLevel.Set(LogLevelWarn)).ShouldNot(HaveOccurred())
+			})
+
+			It("should return the Warn level", func() {
+				Expect(output).Should(Equal(pterm.LogLevelWarn))
+			})
+		})
+
+		Context("Debug", func() {
+			BeforeEach(func() {
+				Expect(logLevel.Set(LogLevelDebug)).ShouldNot(HaveOccurred())
+			})
+
+			It("should return the Debug level", func() {
+				Expect(output).Should(Equal(pterm.LogLevelDebug))
+			})
+		})
+
+		Context("Trace", func() {
+			BeforeEach(func() {
+				Expect(logLevel.Set(LogLevelTrace)).ShouldNot(HaveOccurred())
+			})
+
+			It("should return the Info level", func() {
+				Expect(output).Should(Equal(pterm.LogLevelTrace))
+			})
+		})
+	})
+})

--- a/pkg/options/options_suite_test.go
+++ b/pkg/options/options_suite_test.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestOptions(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Options Suite")
+}

--- a/pkg/output/output_test.go
+++ b/pkg/output/output_test.go
@@ -17,98 +17,335 @@ package output
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"io"
 
+	"github.com/gookit/color"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/pterm/pterm"
 )
 
-var _ = Describe("Output", func() {
+var _ = Describe("NewPrinter func", func() {
 	var (
-		printer *Printer
-		scope   string
-		verbose bool
-		writer  io.Writer
+		printer      *Printer
+		logFormatter pterm.LogFormatter
+		logLevel     pterm.LogLevel
+		writer       io.Writer
 	)
 
 	JustBeforeEach(func() {
-		printer = NewPrinter(scope, false, verbose, writer)
+		printer = NewPrinter(logLevel, logFormatter, writer)
 	})
 
 	JustAfterEach(func() {
 		printer = nil
-		scope = ""
-		verbose = false
+		logFormatter = 1000
+		logLevel = 1000
 		writer = nil
 	})
 
-	Context("a new printer is created", func() {
-		Context("with scope", func() {
-			BeforeEach(func() {
-				scope = "CustomScope"
-			})
-
-			It("should correctly set the scope for each printer object", func() {
-				Expect(printer.Error.Scope.Text).Should(Equal(scope))
-				Expect(printer.Info.Scope.Text).Should(Equal(scope))
-				Expect(printer.Warning.Scope.Text).Should(Equal(scope))
-			})
-		})
-
-		Context("with writer", func() {
-			BeforeEach(func() {
-				writer = &bytes.Buffer{}
-			})
-
-			It("should correctly set the writer for each printer object", func() {
-				Expect(printer.Error.Writer).Should(Equal(writer))
-				Expect(printer.Info.Writer).Should(Equal(writer))
-				Expect(printer.Warning.Writer).Should(Equal(writer))
-				Expect(printer.DefaultText.Writer).Should(Equal(writer))
-			})
-		})
-
-		Context("with verbose", func() {
-			BeforeEach(func() {
-				verbose = true
-			})
-			It("should correctly set the verbose variable to true", func() {
-				Expect(printer.verbose).Should(BeTrue())
-			})
-		})
-	})
-
-	Context("testing output using the verbose function", func() {
-		var (
-			msg          = "Testing verbose mode"
-			customWriter *bytes.Buffer
-		)
-
+	Context("with writer", func() {
 		BeforeEach(func() {
-			// set the output writer.
-			customWriter = &bytes.Buffer{}
-			writer = customWriter
+			writer = &bytes.Buffer{}
 		})
 
-		JustBeforeEach(func() {
-			// call the output function
-			printer.Verbosef("%s", msg)
+		It("should correctly set the writer for each printer object", func() {
+			Expect(printer.Logger.Writer).Should(Equal(writer))
+			Expect(printer.Spinner.Writer).Should(Equal(writer))
+			Expect(printer.DefaultText.Writer).Should(Equal(writer))
+			Expect(printer.TablePrinter.Writer).Should(Equal(writer))
 		})
+	})
 
-		Context("verbose mode is disabled", func() {
-			It("should not output the message", func() {
-				Expect(customWriter.String()).Should(BeEmpty())
-			})
-		})
-
-		Context("verbose mode is enabled", func() {
+	Context("with log-level", func() {
+		Describe("info", func() {
 			BeforeEach(func() {
-				verbose = true
+				logLevel = pterm.LogLevelInfo
 			})
+			It("should correctly set the log level to info", func() {
+				Expect(printer.Logger.Level).Should(Equal(pterm.LogLevelInfo))
+			})
+		})
 
-			It("should output the message", func() {
-				Expect(customWriter.String()).Should(ContainSubstring(msg))
+		Describe("warn", func() {
+			BeforeEach(func() {
+				logLevel = pterm.LogLevelWarn
+			})
+			It("should correctly set the log level to warn", func() {
+				Expect(printer.Logger.Level).Should(Equal(pterm.LogLevelWarn))
+			})
+		})
+
+		Describe("debug", func() {
+			BeforeEach(func() {
+				logLevel = pterm.LogLevelDebug
+			})
+			It("should correctly set the log level to debug", func() {
+				Expect(printer.Logger.Level).Should(Equal(pterm.LogLevelDebug))
+			})
+		})
+
+		Describe("error", func() {
+			BeforeEach(func() {
+				logLevel = pterm.LogLevelError
+			})
+			It("should correctly set the log level to error", func() {
+				Expect(printer.Logger.Level).Should(Equal(pterm.LogLevelError))
 			})
 		})
 	})
+
+	Context("with log-formatter", func() {
+		Describe("colorful", func() {
+			BeforeEach(func() {
+				logFormatter = pterm.LogFormatterColorful
+			})
+			It("should correctly set the log formatter to colorful", func() {
+				Expect(printer.Logger.Formatter).Should(Equal(pterm.LogFormatterColorful))
+			})
+		})
+
+		Describe("json", func() {
+			BeforeEach(func() {
+				logFormatter = pterm.LogFormatterJSON
+			})
+
+			It("should correctly set the log level to json", func() {
+				Expect(printer.Logger.Formatter).Should(Equal(pterm.LogFormatterJSON))
+			})
+
+			It("should correctly disable styling at pterm package level", func() {
+				Expect(pterm.RawOutput).Should(BeTrue())
+			})
+
+			It("should correctly disable color at pterm package level", func() {
+				Expect(pterm.PrintColor).Should(BeFalse())
+			})
+
+			It("should correctly disable color at color package level", func() {
+				Expect(color.Enable).Should(BeFalse())
+			})
+		})
+	})
+})
+
+var _ = Describe("CheckErr func", func() {
+	var (
+		buf     *gbytes.Buffer
+		printer *Printer
+		err     error
+	)
+
+	JustBeforeEach(func() {
+		printer.CheckErr(err)
+	})
+
+	JustAfterEach(func() {
+		printer = nil
+		Expect(buf.Clear()).ShouldNot(HaveOccurred())
+		err = nil
+	})
+
+	Context("printer is nil", func() {
+		BeforeEach(func() {
+			buf = gbytes.NewBuffer()
+			// Set printer to nil.
+			printer = nil
+			err = errors.New("printer is set to nil")
+		})
+
+		It("should print using fmt", func() {
+			Expect(buf).ShouldNot(gbytes.Say(
+				fmt.Sprintf("%s (it seems that the printer has not been initialized, that's why you are seeing this message)", err.Error())))
+		})
+	})
+
+	Context("only printer is active and defined", func() {
+		BeforeEach(func() {
+			buf = gbytes.NewBuffer()
+			// Set printer to nil.
+			printer = NewPrinter(pterm.LogLevelInfo, pterm.LogFormatterColorful, buf)
+			// Make sure that no other printers are active.
+			Expect(printer.ProgressBar).Should(BeNil())
+			Expect(printer.Spinner.IsActive).Should(BeFalse())
+			err = errors.New("only printers without effects")
+		})
+
+		It("should print using fmt", func() {
+			Expect(buf).Should(gbytes.Say(err.Error()))
+		})
+	})
+
+	Context("error is nil", func() {
+		BeforeEach(func() {
+			buf = gbytes.NewBuffer()
+			// Set printer to nil.
+			printer = NewPrinter(pterm.LogLevelInfo, pterm.LogFormatterColorful, buf)
+			// Make sure that no other printers are active.
+			Expect(printer.ProgressBar).Should(BeNil())
+			Expect(printer.Spinner.IsActive).Should(BeFalse())
+			err = nil
+		})
+
+		It("should print nothing", func() {
+			Expect(len(buf.Contents())).Should(BeZero())
+		})
+	})
+
+	Context("spinner is active", func() {
+		BeforeEach(func() {
+			buf = gbytes.NewBuffer()
+			printer = NewPrinter(pterm.LogLevelInfo, pterm.LogFormatterColorful, buf)
+			printer.Spinner, _ = printer.Spinner.Start()
+			// Check that the spinner is active.
+			Expect(printer.Spinner.IsActive).Should(BeTrue())
+			err = errors.New("spinner is active")
+		})
+
+		It("should print using logger", func() {
+			Expect(buf).Should(gbytes.Say(err.Error()))
+		})
+
+		It("should stop the spinner", func() {
+			Expect(printer.Spinner.IsActive).Should(BeFalse())
+		})
+	})
+
+	Context("spinner progress bar is active", func() {
+		BeforeEach(func() {
+			buf = gbytes.NewBuffer()
+			printer = NewPrinter(pterm.LogLevelInfo, pterm.LogFormatterColorful, buf)
+			printer.ProgressBar, _ = NewProgressBar().Start()
+			// Check that the progress bar is active.
+			Expect(printer.ProgressBar.IsActive).Should(BeTrue())
+			err = errors.New("progress bar is active")
+		})
+
+		It("should print using logger", func() {
+			Expect(buf).Should(gbytes.Say(err.Error()))
+		})
+
+		It("should stop the progress bar", func() {
+			Expect(printer.ProgressBar.IsActive).Should(BeFalse())
+		})
+	})
+
+})
+
+var _ = Describe("PrintTable func", func() {
+	var (
+		buf     *gbytes.Buffer
+		printer *Printer
+		header  TableHeader
+		err     error
+	)
+
+	JustBeforeEach(func() {
+		printer = NewPrinter(pterm.LogLevelInfo, pterm.LogFormatterColorful, buf)
+		err = printer.PrintTable(header, nil)
+	})
+
+	JustAfterEach(func() {
+		printer = nil
+		Expect(buf.Clear()).ShouldNot(HaveOccurred())
+		header = 1000
+	})
+
+	Context("artifact search header", func() {
+		BeforeEach(func() {
+			buf = gbytes.NewBuffer()
+			header = ArtifactSearch
+		})
+
+		It("should print header", func() {
+			header := []string{"INDEX", "ARTIFACT", "TYPE", "REGISTRY", "REPOSITORY"}
+			for _, col := range header {
+				Expect(buf).Should(gbytes.Say(col))
+			}
+		})
+	})
+
+	Context("index list header", func() {
+		BeforeEach(func() {
+			buf = gbytes.NewBuffer()
+			header = IndexList
+		})
+
+		It("should print header", func() {
+			header := []string{"NAME", "URL", "ADDED", "UPDATED"}
+			for _, col := range header {
+				Expect(buf).Should(gbytes.Say(col))
+			}
+		})
+	})
+
+	Context("index list header", func() {
+		BeforeEach(func() {
+			buf = gbytes.NewBuffer()
+			header = ArtifactInfo
+		})
+
+		It("should print header", func() {
+			header := []string{"REF", "TAGS"}
+			for _, col := range header {
+				Expect(buf).Should(gbytes.Say(col))
+			}
+		})
+	})
+
+	Context("header is not defined", func() {
+		BeforeEach(func() {
+			buf = gbytes.NewBuffer()
+			header = 1000
+		})
+
+		It("should error", func() {
+			Expect(err).ShouldNot(BeNil())
+		})
+	})
+
+})
+
+var _ = Describe("FormatTitleAsLoggerInfo func", func() {
+	var (
+		printer      *Printer
+		msg          string
+		formattedMsg string
+	)
+
+	JustBeforeEach(func() {
+		printer = NewPrinter(pterm.LogLevelInfo, pterm.LogFormatterColorful, nil)
+		formattedMsg = printer.FormatTitleAsLoggerInfo(msg)
+	})
+
+	JustAfterEach(func() {
+		printer = nil
+	})
+
+	Context("message without trailing new line", func() {
+		BeforeEach(func() {
+			msg = "Testing message without new line"
+		})
+
+		It("should format according to the INFO logger", func() {
+			output := fmt.Sprintf("INFO  %s", msg)
+			Expect(formattedMsg).Should(ContainSubstring(output))
+		})
+	})
+
+	Context("message with trailing new line", func() {
+		BeforeEach(func() {
+			msg = "Testing message with new line"
+		})
+
+		It("should format according to the INFO logger and remove newline", func() {
+			output := fmt.Sprintf("INFO  %s", msg)
+			Expect(formattedMsg).Should(ContainSubstring(output))
+			Expect(formattedMsg).ShouldNot(ContainSubstring("\n"))
+		})
+	})
+
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

 /area cli

 /area tests

> /area examples

**What this PR does / why we need it**:

It's a complete rework of the output system. The scope is to introduce a consistent `logging` and `formatting` across all falcoctl commands. It is done by using `structured logging`, but at the same time objects as `spinners` and `progress bars` are rendered during the operations but removed once done. Furthermore the new logging prints also the `timestamps` which is handy for the `faloctl artifact follow` command. It allows to know when a specific actions has been performed and easies the troubleshooting problems when they occurs.

The old flags `--verbose` and `--disable-styling` have been deprecated and substituted with `--log-level` and `--log-format` flags. It will be completely removed in one of the next releases of falcoctl.

The new log levels supported in falcoctl are:
* Info;
* Debug;
* Warn;
* Trace.
The default value is `Info`.

The new formats are `color, text and json`.

By setting the `--verbose` flag is equivalent to using `--log-level debug` and the `--disable-styling` is equivalent to `--log-format json`

Here are some examples of the new output in falcoctl:

Default logging:
```bash
❯ falcoctl artifact install k8saudit
2023-10-25 12:07:12 INFO  Resolving dependencies ... 
2023-10-25 12:07:13 INFO  Installing artifacts refs: [ghcr.io/falcosecurity/plugins/plugin/k8saudit:latest]
2023-10-25 12:07:13 INFO  Preparing to pull artifact ref: ghcr.io/falcosecurity/plugins/plugin/k8saudit:latest
2023-10-25 12:07:14 INFO  Pulling layer 75ff683c3b71 
2023-10-25 12:07:14 INFO  Pulling layer e2908ebf2c03                                                                  
2023-10-25 12:07:15 INFO  Pulling layer bebd560a926b                                                                  
2023-10-25 12:07:15 INFO  Verifying signature for artifact                                                            
                      └ digest: ghcr.io/falcosecurity/plugins/plugin/k8saudit@sha256:230dfdc0e1d331c5085f3f4c860838dcfc27f9aca8d615ce7d771ace4b621dc6
2023-10-25 12:07:17 INFO  Signature successfully verified! 
2023-10-25 12:07:17 INFO  Extracting and installing artifact type: plugin file: k8saudit-0.6.1-linux-x86_64.tar.gz
2023-10-25 12:07:17 INFO  Artifact successfully installed                                                             
                      ├ name: ghcr.io/falcosecurity/plugins/plugin/k8saudit:latest
                      ├ type: plugin
                      ├ digest: sha256:bebd560a926b9f6234561363ae082daa740abb68b9d6da19bdaf16c13e795a34
                      └ directory: /usr/share/falco/plugins

```
Same as above but in `json format`:
```bash
❯ falcoctl artifact install k8saudit --log-format json
{"level":"INFO","msg":"Resolving dependencies ...","timestamp":"2023-10-25 12:09:10"}
{"level":"INFO","msg":"Installing artifacts","refs":["ghcr.io/falcosecurity/plugins/plugin/k8saudit:latest"],"timestamp":"2023-10-25 12:09:11"}
{"level":"INFO","msg":"Preparing to pull artifact","ref":"ghcr.io/falcosecurity/plugins/plugin/k8saudit:latest","timestamp":"2023-10-25 12:09:11"}
{"level":"INFO","msg":"Pulling layer 75ff683c3b71","timestamp":"2023-10-25 12:09:11"}
{"level":"INFO","msg":"Pulling layer e2908ebf2c03","timestamp":"2023-10-25 12:09:12"}
{"level":"INFO","msg":"Pulling layer bebd560a926b","timestamp":"2023-10-25 12:09:13"}
{"digest":"ghcr.io/falcosecurity/plugins/plugin/k8saudit@sha256:230dfdc0e1d331c5085f3f4c860838dcfc27f9aca8d615ce7d771ace4b621dc6","level":"INFO","msg":"Verifying signature for artifact","timestamp":"2023-10-25 12:09:13"}
{"level":"INFO","msg":"Signature successfully verified!","timestamp":"2023-10-25 12:09:14"}
{"file":"k8saudit-0.6.1-linux-x86_64.tar.gz","level":"INFO","msg":"Extracting and installing artifact","timestamp":"2023-10-25 12:09:14","type":"plugin"}                                                                                          
{"digest":"sha256:bebd560a926b9f6234561363ae082daa740abb68b9d6da19bdaf16c13e795a34","directory":"/usr/share/falco/plugins","level":"INFO","msg":"Artifact successfully installed","name":"ghcr.io/falcosecurity/plugins/plugin/k8saudit:latest","timestamp":"2023-10-25 12:09:14","type":"plugin"}
```
**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
