### PR TITLE
fix(tests): wait for registry to accept connections before running tests

### DIFF
--- a/cmd/artifact/install/install_suite_test.go
+++ b/cmd/artifact/install/install_suite_test.go
@@ -18,9 +18,11 @@ package install_test
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/distribution/distribution/v3/configuration"
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
@@ -81,6 +83,14 @@ var _ = BeforeSuite(func() {
 		err := testutils.StartRegistry(context.Background(), config)
 		Expect(err).ToNot(BeNil())
 	}()
+
+	// Check that the registry is up and accepting connections.
+	Eventually(func(g Gomega) error {
+		res, err := http.Get(fmt.Sprintf("http://%s", config.HTTP.Addr))
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(res.StatusCode).Should(Equal(http.StatusOK))
+		return err
+	}).WithTimeout(time.Second * 5).ShouldNot(HaveOccurred())
 
 	// Create temporary directory used to save the configuration file.
 	configFile, err = testutils.CreateEmptyFile("falcoctl.yaml")

--- a/cmd/registry/auth/basic/basic_suite_test.go
+++ b/cmd/registry/auth/basic/basic_suite_test.go
@@ -109,11 +109,27 @@ var _ = BeforeSuite(func() {
 		Expect(err).ToNot(BeNil())
 	}()
 
+	// Check that the registry is up and accepting connections.
+	Eventually(func(g Gomega) error {
+		res, err := http.Get(fmt.Sprintf("http://%s", config.HTTP.Addr))
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(res.StatusCode).Should(Equal(http.StatusOK))
+		return err
+	}).WithTimeout(time.Second * 5).ShouldNot(HaveOccurred())
+
 	// Start the local registry with basic authentication.
 	go func() {
 		err := testutils.StartRegistry(context.Background(), configBasic)
 		Expect(err).ToNot(BeNil())
 	}()
+
+	// Check that the registry is up and accepting connections.
+	Eventually(func(g Gomega) error {
+		res, err := http.Get(fmt.Sprintf("https://%s", configBasic.HTTP.Addr))
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(res.StatusCode).Should(Equal(http.StatusOK))
+		return err
+	}).WithTimeout(time.Second * 5).ShouldNot(HaveOccurred())
 
 	// Create temporary directory used to save the configuration file.
 	configFile, err = testutils.CreateEmptyFile("falcoctl.yaml")

--- a/cmd/registry/auth/oauth/oauth_suite_test.go
+++ b/cmd/registry/auth/oauth/oauth_suite_test.go
@@ -18,10 +18,12 @@ package oauth_test
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"os/user"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/distribution/distribution/v3/configuration"
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
@@ -94,6 +96,14 @@ var _ = BeforeSuite(func() {
 		err := testutils.StartRegistry(context.Background(), config)
 		Expect(err).ToNot(BeNil())
 	}()
+
+	// Check that the registry is up and accepting connections.
+	Eventually(func(g Gomega) error {
+		res, err := http.Get(fmt.Sprintf("http://%s", config.HTTP.Addr))
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(res.StatusCode).Should(Equal(http.StatusOK))
+		return err
+	}).WithTimeout(time.Second * 5).ShouldNot(HaveOccurred())
 
 	go func() {
 		err := testutils.StartOAuthServer(context.Background(), oauthPort)

--- a/cmd/registry/pull/pull_suite_test.go
+++ b/cmd/registry/pull/pull_suite_test.go
@@ -18,9 +18,11 @@ package pull_test
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/distribution/distribution/v3/configuration"
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
@@ -80,6 +82,14 @@ var _ = BeforeSuite(func() {
 		err := testutils.StartRegistry(context.Background(), config)
 		Expect(err).ToNot(BeNil())
 	}()
+
+	// Check that the registry is up and accepting connections.
+	Eventually(func(g Gomega) error {
+		res, err := http.Get(fmt.Sprintf("http://%s", config.HTTP.Addr))
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(res.StatusCode).Should(Equal(http.StatusOK))
+		return err
+	}).WithTimeout(time.Second * 5).ShouldNot(HaveOccurred())
 
 	// Create temporary directory used to save the configuration file.
 	configFile, err = testutils.CreateEmptyFile("falcoctl.yaml")

--- a/cmd/registry/push/push_suite_test.go
+++ b/cmd/registry/push/push_suite_test.go
@@ -18,9 +18,11 @@ package push_test
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/distribution/distribution/v3/configuration"
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
@@ -81,6 +83,14 @@ var _ = BeforeSuite(func() {
 		err := testutils.StartRegistry(context.Background(), config)
 		Expect(err).ToNot(BeNil())
 	}()
+
+	// Check that the registry is up and accepting connections.
+	Eventually(func(g Gomega) error {
+		res, err := http.Get(fmt.Sprintf("http://%s", config.HTTP.Addr))
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(res.StatusCode).Should(Equal(http.StatusOK))
+		return err
+	}).WithTimeout(time.Second * 5).ShouldNot(HaveOccurred())
 
 	// Create temporary directory used to save the configuration file.
 	configFile, err = testutils.CreateEmptyFile("falcoctl.yaml")

--- a/pkg/oci/pusher/pusher_suite_test.go
+++ b/pkg/oci/pusher/pusher_suite_test.go
@@ -18,7 +18,9 @@ package pusher_test
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/distribution/distribution/v3/configuration"
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
@@ -62,4 +64,12 @@ var _ = BeforeSuite(func() {
 		err := testutils.StartRegistry(context.Background(), config)
 		Expect(err).ToNot(BeNil())
 	}()
+
+	// Check that the registry is up and accepting connections.
+	Eventually(func(g Gomega) error {
+		res, err := http.Get(fmt.Sprintf("http://%s", config.HTTP.Addr))
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(res.StatusCode).Should(Equal(http.StatusOK))
+		return err
+	}).WithTimeout(time.Second * 5).ShouldNot(HaveOccurred())
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

/kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

> /area cli

/area tests

> /area examples

**What this PR does / why we need it**:

Fixes the failure of some tests caused by race conditions. Tests that interacts with a `registry` wait for it until it accepts connections.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
