### PR TITLE
chore(pkg/driver): do not fail if /sys/kernel/debug fails to be mounted.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/distribution/distribution/v3 v3.0.0-20230608105614-4501a6e06d3b
 	github.com/docker/cli v24.0.7+incompatible
 	github.com/docker/docker v24.0.7+incompatible
-	github.com/falcosecurity/driverkit v0.15.5-0.20231108173325-1babd00be84f
+	github.com/falcosecurity/driverkit v0.16.0
 	github.com/go-oauth2/oauth2/v4 v4.5.2
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/go-containerregistry v0.16.1

--- a/go.sum
+++ b/go.sum
@@ -333,8 +333,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/falcosecurity/driverkit v0.15.5-0.20231108173325-1babd00be84f h1:J18YO8qW1vHbFpue+ga0KS8vjXmF7Wkqd2juqFotcB0=
-github.com/falcosecurity/driverkit v0.15.5-0.20231108173325-1babd00be84f/go.mod h1:vGGEx4jQFuTCYdPn70Pb7d3PjrgBULCKhOlW/serJTw=
+github.com/falcosecurity/driverkit v0.16.0 h1:riTkoDVJjoO00kojzm9rNvXu0aQs3phWp+4+VJjt+Ws=
+github.com/falcosecurity/driverkit v0.16.0/go.mod h1:vGGEx4jQFuTCYdPn70Pb7d3PjrgBULCKhOlW/serJTw=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area library

**What this PR does / why we need it**:

Mount `/sys/kernel/debug` can fail in lots of circumstances; for example if it is already mounted.
Since we don't always need it (indeed we only need it for x86_64 kernel releases between 4.14 and 4.17), just don't fail.
This is the same behavior that the old falco-driver-loader had: https://github.com/falcosecurity/falco/blob/master/scripts/falco-driver-loader#L628.

Also, bumped driverkit library to v0.16.0 (latest release).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
