### PR TITLE
fix(pkg/driver): do not call FixupKernel when building drivers.

### DIFF
--- a/cmd/driver/printenv/printenv.go
+++ b/cmd/driver/printenv/printenv.go
@@ -72,10 +72,13 @@ func (o *driverPrintenvOptions) RunDriverPrintenv(_ context.Context) error {
 	}
 	o.Printer.DefaultText.Printf("TARGET_ID=%q\n", d.String())
 
+	o.Printer.DefaultText.Printf("ARCH=%q\n", kr.Architecture.ToNonDeb())
+	o.Printer.DefaultText.Printf("KERNEL_RELEASE=%q\n", kr.String())
+	o.Printer.DefaultText.Printf("KERNEL_VERSION=%q\n", kr.KernelVersion)
+
 	fixedKr := d.FixupKernel(kr)
-	o.Printer.DefaultText.Printf("ARCH=%q\n", fixedKr.Architecture.ToNonDeb())
-	o.Printer.DefaultText.Printf("KERNEL_RELEASE=%q\n", fixedKr.String())
-	o.Printer.DefaultText.Printf("KERNEL_VERSION=%q\n", fixedKr.KernelVersion)
+	o.Printer.DefaultText.Printf("FIXED_KERNEL_RELEASE=%q\n", fixedKr.String())
+	o.Printer.DefaultText.Printf("FIXED_KERNEL_VERSION=%q\n", fixedKr.KernelVersion)
 
 	return nil
 }

--- a/pkg/driver/distro/distro.go
+++ b/pkg/driver/distro/distro.go
@@ -178,7 +178,7 @@ func Build(ctx context.Context,
 	if err != nil {
 		return "", err
 	}
-	path, err := driverType.Build(ctx, printer, d.FixupKernel(kr), driverName, driverVer, env)
+	path, err := driverType.Build(ctx, printer, kr, driverName, driverVer, env)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/driver/distro/flatcar.go
+++ b/pkg/driver/distro/flatcar.go
@@ -76,7 +76,8 @@ func (f *flatcar) init(kr kernelrelease.KernelRelease, id string, cfg *ini.File)
 func (f *flatcar) FixupKernel(kr kernelrelease.KernelRelease) kernelrelease.KernelRelease {
 	kr.Version = semver.MustParse(f.versionID)
 	kr.Fullversion = kr.Version.String()
-	return kr
+	kr.FullExtraversion = ""
+	return f.generic.FixupKernel(kr)
 }
 
 //nolint:gocritic // the method shall not be able to modify kr
@@ -93,6 +94,9 @@ func (f *flatcar) customizeBuild(ctx context.Context,
 		return nil, nil
 	}
 	printer.Logger.Info("Flatcar detected; relocating kernel tools.", printer.Logger.Args("version", f.versionID))
-	_, err := exec.CommandContext(ctx, "/bin/bash", "-c", flatcarRelocateScript).Output()
+	out, err := exec.CommandContext(ctx, "/bin/bash", "-c", flatcarRelocateScript).Output()
+	if err != nil {
+		printer.DefaultText.Print(string(out))
+	}
 	return nil, err
 }

--- a/pkg/driver/distro/flatcar_test.go
+++ b/pkg/driver/distro/flatcar_test.go
@@ -62,3 +62,34 @@ func TestDistroFlatcarInitFixup(t *testing.T) {
 		}
 	}
 }
+
+func TestDistroFlatcarFixup(t *testing.T) {
+	type testCase struct {
+		krInput    string
+		kvInput    string
+		krExpected string
+		kvExpected string
+	}
+	testCases := []testCase{
+		{
+			krInput:    "6.1.62-flatcar",
+			kvInput:    "#1 SMP PREEMPT_DYNAMIC Mon Nov 20 22:57:52 -00 2023",
+			krExpected: "3794.0.0",
+			kvExpected: "1",
+		},
+		{
+			krInput:    "6.1.62-flatcar",
+			kvInput:    "#27 SMP PREEMPT_DYNAMIC Mon Nov 20 22:57:52 -00 2023",
+			krExpected: "3794.0.0",
+			kvExpected: "27",
+		},
+	}
+	for _, tCase := range testCases {
+		flat := &flatcar{generic: &generic{}, versionID: "3794.0.0"}
+		kr := kernelrelease.FromString(tCase.krInput)
+		kr.KernelVersion = tCase.kvInput
+		fixedKr := flat.FixupKernel(kr)
+		assert.Equal(t, tCase.krExpected, fixedKr.String())
+		assert.Equal(t, tCase.kvExpected, fixedKr.KernelVersion)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area library

**What this PR does / why we need it**:

Moreover, call `return f.generic.FixupKernel(kr)` in flatcar FixupKernel.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #372 

**Special notes for your reviewer**:
