### PR TITLE
pkg/driver/flatcar: Update the script

### DIFF
--- a/pkg/driver/distro/flatcar.go
+++ b/pkg/driver/distro/flatcar.go
@@ -28,29 +28,57 @@ import (
 )
 
 const flatcarRelocateScript = `
-local -a tools=(
-		scripts/basic/fixdep
-		scripts/mod/modpost
-		tools/objtool/objtool
-	)
-local -r hostld=$(ls /host/usr/lib64/ld-linux-*.so.*)
-local -r kdir=/lib/modules/$(ls /lib/modules/)/build
-echo "** Found host dl interpreter: ${hostld}"
-for host_tool in ${tools[@]}; do
-	t=${host_tool}
-	tool=$(basename $t)
-	tool_dir=$(dirname $t)
-	host_tool=${kdir}/${host_tool}
-	if [ ! -f ${host_tool} ]; then
+set -euo pipefail
+
+shopt -s nullglob
+
+hostlds=( /host/usr/lib64/ld-linux-*.so.* )
+if [[ ${#hostlds[@]} -eq 0 ]]; then
+	echo "** no dynamic loaders found"
+	exit 1
+fi
+if [[ ${#hostlds[@]} -gt 1 ]]; then
+	echo "** more than one fitting dynamic loader found, picking first"
+fi
+hostld=${hostlds[0]}
+echo "** Found host dynamic loader: ${hostld}"
+
+kdirs=( /host/lib/modules/*/build )
+if [[ ${#kdirs[@]} -eq 0 ]]; then
+	echo "** no kernel module tools directories found"
+	exit 1
+fi
+if [[ ${#kdirs[@]} -gt 1 ]]; then
+	echo "** more than one fitting kernel module tools directory found, picking first"
+fi
+kdir=${kdirs[0]}
+echo "** Found kernel tools directory: ${kdir}"
+
+tools=(
+	scripts/basic/fixdep
+	scripts/mod/modpost
+	tools/objtool/objtool
+)
+
+tmp_dir=$(mktemp -d)
+for tool in "${tools[@]}"; do
+	host_tool=${kdir}/${tool}
+	if [[ ! -f ${host_tool} ]]; then
+		echo "${tool@Q} not found in ${kdir@Q}, not patching"
 		continue
 	fi
-	umount ${host_tool} 2>/dev/null || true
-	mkdir -p /tmp/${tool_dir}/
-	cp -a ${host_tool} /tmp/${tool_dir}/
-	echo "** Setting host dl interpreter for $host_tool"
-	patchelf --set-interpreter ${hostld} --set-rpath /host/usr/lib64 /tmp/${tool_dir}/${tool}
-	mount -o bind /tmp/${tool_dir}/${tool} ${host_tool}
+	umount "${host_tool}" 2>/dev/null || true
+	tmp_tool=${tmp_dir}/${tool}
+	mkdir -p "$(dirname "${tmp_tool}")"
+	cp -a "${host_tool}" "${tmp_tool}"
+	echo "** Setting host dynamic loader for ${tool@Q}"
+	patchelf \
+		--set-interpreter "${hostld}" \
+		--set-rpath /host/usr/lib64 \
+		"${tmp_tool}"
+	mount -o bind "${tmp_tool}" "${host_tool}"
 done
+rm -rf "${tmp_dir}"
 `
 
 func init() {
@@ -94,7 +122,7 @@ func (f *flatcar) customizeBuild(ctx context.Context,
 		return nil, nil
 	}
 	printer.Logger.Info("Flatcar detected; relocating kernel tools.", printer.Logger.Args("version", f.versionID))
-	out, err := exec.CommandContext(ctx, "/bin/bash", "-c", flatcarRelocateScript).Output()
+	out, err := exec.CommandContext(ctx, "/bin/bash", "-c", flatcarRelocateScript).CombinedOutput()
 	if err != nil {
 		printer.DefaultText.Print(string(out))
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area library

**What this PR does / why we need it**:

Fixes building kernel module on Flatcar. The bash script that was relocating the kernel tools had some issues.

It was taken straight from the old driver loader bash script, but now it's a separate script, so some constructs like `local` make no sense there. A result was that no kernel tools were patched, thus they could fail to run if they were built against a newer glibc than the one provided by the falco-driver-loader image.

Also print the output of the script unconditionally, so we may have some idea about what's going on here.

**Special notes for your reviewer**:

I hope that hardcoding `/host` as host root is fine - I can't see it being provided for customization purposes. Using HOST_ROOT env var wouldn't work if it was provided through `--host-root` flag.