### PR TITLE
fix(pkg/driver): fixed generic kernelversion fixup method.

### DIFF
--- a/pkg/driver/distro/generic.go
+++ b/pkg/driver/distro/generic.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 The Falco Authors
+// Copyright (C) 2024 The Falco Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package driverdistro
 
 import (
-	"strings"
+	"regexp"
 
 	"github.com/blang/semver"
 	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
@@ -26,6 +26,14 @@ import (
 	drivertype "github.com/falcosecurity/falcoctl/pkg/driver/type"
 	"github.com/falcosecurity/falcoctl/pkg/output"
 )
+
+// Parse start of string as "#NUMBER":
+// eg1: "#1 SMP PREEMPT_DYNAMIC Tue, 10 Oct 2023 21:10:21 +0000" -> "1".
+// eg2: #1-photon -> "1"
+// Old falco-driver-loader method did:
+// echo "${DRIVER_KERNEL_VERSION}" | sed 's/#\([[:digit:]]\+\).*/\1/'
+// The regex does the same thing.
+var genericKernelVersionRegex = regexp.MustCompile(`#(\d+).*`)
 
 type generic struct {
 	targetID string
@@ -43,10 +51,11 @@ func (g *generic) String() string {
 
 //nolint:gocritic // the method shall not be able to modify kr
 func (g *generic) FixupKernel(kr kernelrelease.KernelRelease) kernelrelease.KernelRelease {
-	// Take eg: "#1 SMP PREEMPT_DYNAMIC Tue, 10 Oct 2023 21:10:21 +0000" and return "1".
-	kv := strings.TrimLeft(kr.KernelVersion, "#")
-	kv = strings.Split(kv, " ")[0]
-	kr.KernelVersion = kv
+	matches := genericKernelVersionRegex.FindStringSubmatch(kr.KernelVersion)
+	if len(matches) == 0 {
+		return kr
+	}
+	kr.KernelVersion = matches[1]
 	return kr
 }
 

--- a/pkg/driver/distro/generic.go
+++ b/pkg/driver/distro/generic.go
@@ -52,10 +52,9 @@ func (g *generic) String() string {
 //nolint:gocritic // the method shall not be able to modify kr
 func (g *generic) FixupKernel(kr kernelrelease.KernelRelease) kernelrelease.KernelRelease {
 	matches := genericKernelVersionRegex.FindStringSubmatch(kr.KernelVersion)
-	if len(matches) == 0 {
-		return kr
+	if len(matches) == 2 {
+		kr.KernelVersion = matches[1]
 	}
-	kr.KernelVersion = matches[1]
 	return kr
 }
 

--- a/pkg/driver/distro/generic_test.go
+++ b/pkg/driver/distro/generic_test.go
@@ -44,6 +44,11 @@ func TestDistroGeneric(t *testing.T) {
 			kvInput:    "#231asfa #rf3f",
 			kvExpected: "231",
 		},
+		{
+			krInput:    "6.7.2-arch1-2",
+			kvInput:    "#231asfa234",
+			kvExpected: "231",
+		},
 	}
 
 	g := &generic{}

--- a/pkg/driver/distro/generic_test.go
+++ b/pkg/driver/distro/generic_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package driverdistro
+
+import (
+	"testing"
+
+	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDistroGeneric(t *testing.T) {
+	type testCase struct {
+		krInput    string
+		kvInput    string
+		kvExpected string
+	}
+	testCases := []testCase{
+		{
+			krInput:    "4.19.283-3.ph3",
+			kvInput:    "#1-photon SMP Fri Jun 16 02:25:27 UTC 2023",
+			kvExpected: "1",
+		},
+		{
+			krInput:    "6.7.2-arch1-2",
+			kvInput:    "#1 SMP PREEMPT_DYNAMIC Wed, 31 Jan 2024 09:22:15 +0000",
+			kvExpected: "1",
+		},
+		{
+			krInput:    "6.7.2-arch1-2",
+			kvInput:    "#231asfa #rf3f",
+			kvExpected: "231",
+		},
+	}
+
+	g := &generic{}
+	for _, tCase := range testCases {
+		kr := kernelrelease.FromString(tCase.krInput)
+		kr.KernelVersion = tCase.kvInput
+		fixedKr := g.FixupKernel(kr)
+		assert.Equal(t, tCase.kvExpected, fixedKr.KernelVersion)
+	}
+}

--- a/pkg/driver/distro/ubuntu.go
+++ b/pkg/driver/distro/ubuntu.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 The Falco Authors
+// Copyright (C) 2024 The Falco Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -59,7 +59,8 @@ func (u *ubuntu) FixupKernel(kr kernelrelease.KernelRelease) kernelrelease.Kerne
 	// so that eg: we receive "26~22.04.1-Ubuntu",
 	// therefore we only need to drop "-Ubuntu" suffix
 	// Take eg: "#1 SMP PREEMPT_DYNAMIC Tue, 10 Oct 2023 21:10:21 +0000" and return "1".
-	kr = u.generic.FixupKernel(kr)
-	kr.KernelVersion = strings.TrimSuffix(kr.KernelVersion, "-Ubuntu")
+	kv := strings.TrimLeft(kr.KernelVersion, "#")
+	kv = strings.Split(kv, " ")[0]
+	kr.KernelVersion = strings.TrimSuffix(kv, "-Ubuntu")
 	return kr
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area library

**What this PR does / why we need it**:

This PR fixes an issue with the `fixupKernel` method on the `generic` distro receiver, porting it to use same logic as the old falco-driver-loader script: https://github.com/falcosecurity/falco/blob/1b62b5ccd1c64cd972ef0252262075cbf42a130c/scripts/falco-driver-loader#L713

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
