### PR TITLE
new(cmd/driver): support user provided headers option for driver download

### DIFF
--- a/cmd/driver/install/install.go
+++ b/cmd/driver/install/install.go
@@ -95,9 +95,8 @@ func NewDriverInstallCmd(ctx context.Context, opt *options.Common, driver *optio
 	cmd.Flags().DurationVar(&o.HTTPTimeout, "http-timeout", 60*time.Second, "Timeout for each http try")
 	cmd.Flags().StringVar(&o.HTTPHeaders, "http-headers",
 		"",
-		"Optional comma-separated list of headers for the http GET request\n"+
-			"(e.g. --http-headers=\"x-emc-namespace: default,Proxy-Authenticate: Basic\").\n"+
-			"Not necessary if default repo is used")
+		"Optional comma-separated list of headers for the http GET request "+
+			"(e.g. --http-headers='x-emc-namespace: default,Proxy-Authenticate: Basic'). Not necessary if default repo is used")
 	return cmd
 }
 

--- a/cmd/driver/install/install.go
+++ b/cmd/driver/install/install.go
@@ -36,6 +36,7 @@ import (
 type driverDownloadOptions struct {
 	InsecureDownload bool
 	HTTPTimeout      time.Duration
+	HTTPHeaders      string
 }
 
 type driverInstallOptions struct {
@@ -92,6 +93,11 @@ func NewDriverInstallCmd(ctx context.Context, opt *options.Common, driver *optio
 			"(e.g. '#1 SMP PREEMPT_DYNAMIC Debian 6.1.38-2 (2023-07-27)')")
 	cmd.Flags().BoolVar(&o.InsecureDownload, "http-insecure", false, "Whether you want to allow insecure downloads or not")
 	cmd.Flags().DurationVar(&o.HTTPTimeout, "http-timeout", 60*time.Second, "Timeout for each http try")
+	cmd.Flags().StringVar(&o.HTTPHeaders, "http-headers",
+		"",
+		"Optional comma-separated list of headers for the http GET request\n"+
+			"(e.g. --http-headers=\"x-emc-namespace: default,Proxy-Authenticate: Basic\").\n"+
+			"Not necessary if default repo is used")
 	return cmd
 }
 
@@ -173,7 +179,8 @@ func (o *driverInstallOptions) RunDriverInstall(ctx context.Context) (string, er
 		if !o.Printer.DisableStyling {
 			o.Printer.Spinner, _ = o.Printer.Spinner.Start("Trying to download the driver")
 		}
-		dest, err = driverdistro.Download(ctx, d, o.Printer.WithWriter(&buf), kr, o.Driver.Name, o.Driver.Type, o.Driver.Version, o.Driver.Repos)
+		dest, err = driverdistro.Download(ctx, d, o.Printer.WithWriter(&buf), kr, o.Driver.Name,
+			o.Driver.Type, o.Driver.Version, o.Driver.Repos, o.HTTPHeaders)
 		if o.Printer.Spinner != nil {
 			_ = o.Printer.Spinner.Stop()
 		}

--- a/cmd/driver/install/install_test.go
+++ b/cmd/driver/install/install_test.go
@@ -36,6 +36,7 @@ Flags:
       --compile                 Whether to enable local compilation of drivers (default true)
       --download                Whether to enable download of prebuilt drivers (default true)
   -h, --help                    help for install
+      --http-headers string     Optional comma-separated list of headers for the http GET request (e.g. --http-headers='x-emc-namespace: default,Proxy-Authenticate: Basic'). Not necessary if default repo is used
       --http-insecure           Whether you want to allow insecure downloads or not
       --http-timeout duration   Timeout for each http try (default 1m0s)
       --kernelrelease string    Specify the kernel release for which to download/build the driver in the same format used by 'uname -r' (e.g. '6.1.0-10-cloud-amd64')

--- a/pkg/driver/distro/distro.go
+++ b/pkg/driver/distro/distro.go
@@ -203,6 +203,7 @@ func Download(ctx context.Context,
 	driverName string,
 	driverType drivertype.DriverType,
 	driverVer string, repos []string,
+	httpHeaders string,
 ) (string, error) {
 	driverFileName := toFilename(d, &kr, driverName, driverType)
 	// Skip if existent
@@ -221,6 +222,17 @@ func Download(ctx context.Context,
 		if err != nil {
 			printer.Logger.Warn("Error creating http request.", printer.Logger.Args("err", err))
 			continue
+		}
+		if httpHeaders != "" {
+			header := http.Header{}
+			for _, h := range strings.Split(httpHeaders, ",") {
+				key, value := func() (string, string) {
+					x := strings.Split(h, ":")
+					return x[0], x[1]
+				}()
+				header.Add(key, value)
+			}
+			req.Header = header
 		}
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil || resp.StatusCode != 200 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the Falco `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:
Added option to add headers in the http GET request for the driver download

**Which issue(s) this PR fixes**:
Option had been possible via environment variables in the script based download but is not possible anymore since the falcoctl migration

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #426

**Special notes for your reviewer**:
example flag (for testing):
--http-headers="x-emc-namespace: default,Proxy-Authenticate: Basic"