### PR TITLE
fix(registry/push): correctly remove temporary dir

### DIFF
--- a/internal/utils/compress.go
+++ b/internal/utils/compress.go
@@ -28,7 +28,7 @@ import (
 
 // TmpDirPrefix prefix used for the temporary directory where the tar.gz archives live before pushing
 // to the OCI registry.
-const TmpDirPrefix = "falcoctl-registry-push"
+const TmpDirPrefix = "falcoctl-registry-push-"
 
 // CreateTarGzArchive compresses and saves in a tar archive the passed file.
 func CreateTarGzArchive(path string) (file string, err error) {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the Falco `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

When pushing multiple plugins we need to remove the temporary dirs created when compressing them. This commit implements a fix that tracks all the temporary dirs created at runtime and removes them at the end.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
