### PR TITLE
new: driver selection logic

### DIFF
--- a/cmd/driver/cleanup/cleanup_test.go
+++ b/cmd/driver/cleanup/cleanup_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/falcosecurity/falcoctl/cmd"
 )
 
+//nolint:lll // no need to check for line length.
 var driverCleanupHelp = `[Preview] Cleans a driver up, eg for kmod, by removing it from dkms.
 ** This command is in preview and under development. **
 
@@ -35,14 +36,16 @@ Flags:
   -h, --help   help for cleanup
 
 Global Flags:
-      --config string       config file to be used for falcoctl (default "/etc/falcoctl/falcoctl.yaml")
-      --host-root string    Driver host root to be used. (default "/")
-      --log-format string   Set formatting for logs (color, text, json) (default "color")
-      --log-level string    Set level for logs (info, warn, debug, trace) (default "info")
-      --name string         Driver name to be used. (default "falco")
-      --repo strings        Driver repo to be used. (default [https://download.falco.org/driver])
-      --type string         Driver type to be used (auto, ebpf, kmod, modern_ebpf) (default "kmod")
-      --version string      Driver version to be used.
+      --config string          config file to be used for falcoctl (default "/etc/falcoctl/falcoctl.yaml")
+      --host-root string       Driver host root to be used. (default "/")
+      --kernelrelease string   Specify the kernel release for which to download/build the driver in the same format used by 'uname -r' (e.g. '6.1.0-10-cloud-amd64')
+      --kernelversion string   Specify the kernel version for which to download/build the driver in the same format used by 'uname -v' (e.g. '#1 SMP PREEMPT_DYNAMIC Debian 6.1.38-2 (2023-07-27)')
+      --log-format string      Set formatting for logs (color, text, json) (default "color")
+      --log-level string       Set level for logs (info, warn, debug, trace) (default "info")
+      --name string            Driver name to be used. (default "falco")
+      --repo strings           Driver repo to be used. (default [https://download.falco.org/driver])
+      --type strings           Driver types allowed in descending priority order (ebpf, kmod, modern_ebpf) (default [modern_ebpf,ebpf,kmod])
+      --version string         Driver version to be used.
 `
 
 var addAssertFailedBehavior = func(specificError string) {
@@ -93,8 +96,7 @@ var _ = Describe("cleanup", func() {
 			BeforeEach(func() {
 				args = []string{driverCmd, cleanupCmd, "--config", configFile, "--type", "foo"}
 			})
-			addAssertFailedBehavior(`ERROR invalid argument "foo" for "--type" flag: invalid argument "foo",` +
-				` please provide one of (auto, ebpf, kmod, modern_ebpf)`)
+			addAssertFailedBehavior(`ERROR unsupported driver type specified: foo`)
 		})
 	})
 })

--- a/cmd/driver/cleanup/cleanup_test.go
+++ b/cmd/driver/cleanup/cleanup_test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 The Falco Authors
+// Copyright (C) 2024 The Falco Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/driver/config/config_test.go
+++ b/cmd/driver/config/config_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/falcosecurity/falcoctl/cmd"
 )
 
+//nolint:lll // no need to check for line length.
 var driverConfigHelp = `[Preview] Configure a driver for future usages with other driver subcommands.
 It will also update local Falco configuration or k8s configmap depending on the environment where it is running, to let Falco use chosen driver.
 Only supports deployments of Falco that use a driver engine, ie: one between kmod, ebpf and modern-ebpf.
@@ -41,14 +42,16 @@ Flags:
       --update-falco        Whether to update Falco config/configmap. (default true)
 
 Global Flags:
-      --config string       config file to be used for falcoctl (default "/etc/falcoctl/falcoctl.yaml")
-      --host-root string    Driver host root to be used. (default "/")
-      --log-format string   Set formatting for logs (color, text, json) (default "color")
-      --log-level string    Set level for logs (info, warn, debug, trace) (default "info")
-      --name string         Driver name to be used. (default "falco")
-      --repo strings        Driver repo to be used. (default [https://download.falco.org/driver])
-      --type string         Driver type to be used (auto, ebpf, kmod, modern_ebpf) (default "kmod")
-      --version string      Driver version to be used.
+      --config string          config file to be used for falcoctl (default "/etc/falcoctl/falcoctl.yaml")
+      --host-root string       Driver host root to be used. (default "/")
+      --kernelrelease string   Specify the kernel release for which to download/build the driver in the same format used by 'uname -r' (e.g. '6.1.0-10-cloud-amd64')
+      --kernelversion string   Specify the kernel version for which to download/build the driver in the same format used by 'uname -v' (e.g. '#1 SMP PREEMPT_DYNAMIC Debian 6.1.38-2 (2023-07-27)')
+      --log-format string      Set formatting for logs (color, text, json) (default "color")
+      --log-level string       Set level for logs (info, warn, debug, trace) (default "info")
+      --name string            Driver name to be used. (default "falco")
+      --repo strings           Driver repo to be used. (default [https://download.falco.org/driver])
+      --type strings           Driver types allowed in descending priority order (ebpf, kmod, modern_ebpf) (default [modern_ebpf,ebpf,kmod])
+      --version string         Driver version to be used.
 `
 
 var addAssertFailedBehavior = func(specificError string) {
@@ -99,8 +102,7 @@ var _ = Describe("config", func() {
 			BeforeEach(func() {
 				args = []string{driverCmd, configCmd, "--config", configFile, "--type", "foo"}
 			})
-			addAssertFailedBehavior(`ERROR invalid argument "foo" for "--type" flag: invalid argument "foo",` +
-				` please provide one of (auto, ebpf, kmod, modern_ebpf)`)
+			addAssertFailedBehavior(`ERROR unsupported driver type specified: foo`)
 		})
 	})
 })

--- a/cmd/driver/config/config_test.go
+++ b/cmd/driver/config/config_test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 The Falco Authors
+// Copyright (C) 2024 The Falco Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/driver/driver_linux.go
+++ b/cmd/driver/driver_linux.go
@@ -166,9 +166,9 @@ func NewDriverCmd(ctx context.Context, opt *options.Common) *cobra.Command {
 					info.String(),
 					info.KernelVersion,
 					info.Architecture.ToNonDeb())
-			} else {
-				opt.Printer.Logger.Debug("Detected supported driver", opt.Printer.Logger.Args("type", driver.Type.String()))
 			}
+			opt.Printer.Logger.Debug("Detected supported driver", opt.Printer.Logger.Args("type", driver.Type.String()))
+
 			// If empty, try to load it automatically from /usr/src sub folders,
 			// using the most recent (ie: the one with greatest semver) driver version.
 			if driver.Version == "" {
@@ -178,7 +178,8 @@ func NewDriverCmd(ctx context.Context, opt *options.Common) *cobra.Command {
 		},
 	}
 
-	cmd.PersistentFlags().StringSliceVar(&driverTypesStr, "type", config.DefaultDriver.Type, "Driver types allowed in descending priority order "+driverTypesEnum.Allowed())
+	cmd.PersistentFlags().StringSliceVar(&driverTypesStr, "type", config.DefaultDriver.Type,
+		"Driver types allowed in descending priority order "+driverTypesEnum.Allowed())
 	cmd.PersistentFlags().StringVar(&driver.Version, "version", config.DefaultDriver.Version, "Driver version to be used.")
 	cmd.PersistentFlags().StringSliceVar(&driver.Repos, "repo", config.DefaultDriver.Repos, "Driver repo to be used.")
 	cmd.PersistentFlags().StringVar(&driver.Name, "name", config.DefaultDriver.Name, "Driver name to be used.")

--- a/cmd/driver/driver_linux.go
+++ b/cmd/driver/driver_linux.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 The Falco Authors
+// Copyright (C) 2024 The Falco Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/driver/driver_others.go
+++ b/cmd/driver/driver_others.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 The Falco Authors
+// Copyright (C) 2024 The Falco Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/driver/install/install.go
+++ b/cmd/driver/install/install.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 The Falco Authors
+// Copyright (C) 2024 The Falco Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/driver/install/install_test.go
+++ b/cmd/driver/install/install_test.go
@@ -39,18 +39,18 @@ Flags:
       --http-headers string     Optional comma-separated list of headers for the http GET request (e.g. --http-headers='x-emc-namespace: default,Proxy-Authenticate: Basic'). Not necessary if default repo is used
       --http-insecure           Whether you want to allow insecure downloads or not
       --http-timeout duration   Timeout for each http try (default 1m0s)
-      --kernelrelease string    Specify the kernel release for which to download/build the driver in the same format used by 'uname -r' (e.g. '6.1.0-10-cloud-amd64')
-      --kernelversion string    Specify the kernel version for which to download/build the driver in the same format used by 'uname -v' (e.g. '#1 SMP PREEMPT_DYNAMIC Debian 6.1.38-2 (2023-07-27)')
 
 Global Flags:
-      --config string       config file to be used for falcoctl (default "/etc/falcoctl/falcoctl.yaml")
-      --host-root string    Driver host root to be used. (default "/")
-      --log-format string   Set formatting for logs (color, text, json) (default "color")
-      --log-level string    Set level for logs (info, warn, debug, trace) (default "info")
-      --name string         Driver name to be used. (default "falco")
-      --repo strings        Driver repo to be used. (default [https://download.falco.org/driver])
-      --type string         Driver type to be used (auto, ebpf, kmod, modern_ebpf) (default "kmod")
-      --version string      Driver version to be used.
+      --config string          config file to be used for falcoctl (default "/etc/falcoctl/falcoctl.yaml")
+      --host-root string       Driver host root to be used. (default "/")
+      --kernelrelease string   Specify the kernel release for which to download/build the driver in the same format used by 'uname -r' (e.g. '6.1.0-10-cloud-amd64')
+      --kernelversion string   Specify the kernel version for which to download/build the driver in the same format used by 'uname -v' (e.g. '#1 SMP PREEMPT_DYNAMIC Debian 6.1.38-2 (2023-07-27)')
+      --log-format string      Set formatting for logs (color, text, json) (default "color")
+      --log-level string       Set level for logs (info, warn, debug, trace) (default "info")
+      --name string            Driver name to be used. (default "falco")
+      --repo strings           Driver repo to be used. (default [https://download.falco.org/driver])
+      --type strings           Driver types allowed in descending priority order (ebpf, kmod, modern_ebpf) (default [modern_ebpf,ebpf,kmod])
+      --version string         Driver version to be used.
 `
 
 var addAssertFailedBehavior = func(specificError string) {
@@ -115,8 +115,7 @@ var _ = Describe("install", func() {
 			BeforeEach(func() {
 				args = []string{driverCmd, installCmd, "--config", configFile, "--type", "foo", "--version", "1.0.0+driver"}
 			})
-			addAssertFailedBehavior(`ERROR invalid argument "foo" for "--type" flag: invalid argument "foo",` +
-				` please provide one of (auto, ebpf, kmod, modern_ebpf)`)
+			addAssertFailedBehavior(`ERROR unsupported driver type specified: foo`)
 		})
 	})
 

--- a/cmd/driver/install/install_test.go
+++ b/cmd/driver/install/install_test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 The Falco Authors
+// Copyright (C) 2024 The Falco Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/driver/printenv/printenv.go
+++ b/cmd/driver/printenv/printenv.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 The Falco Authors
+// Copyright (C) 2024 The Falco Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/driver/printenv/printenv.go
+++ b/cmd/driver/printenv/printenv.go
@@ -16,14 +16,11 @@
 package driverprintenv
 
 import (
-	"errors"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
 
-	driverdistro "github.com/falcosecurity/falcoctl/pkg/driver/distro"
-	driverkernel "github.com/falcosecurity/falcoctl/pkg/driver/kernel"
 	"github.com/falcosecurity/falcoctl/pkg/options"
 )
 
@@ -45,7 +42,7 @@ func NewDriverPrintenvCmd(ctx context.Context, opt *options.Common, driver *opti
 		Short:                 "[Preview] Print env vars",
 		Long: `[Preview] Print variables used by driver as env vars.
 ** This command is in preview and under development. **`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return o.RunDriverPrintenv(ctx)
 		},
 	}
@@ -58,27 +55,12 @@ func (o *driverPrintenvOptions) RunDriverPrintenv(_ context.Context) error {
 	o.Printer.DefaultText.Printf("DRIVER_VERSION=%q\n", o.Driver.Version)
 	o.Printer.DefaultText.Printf("DRIVER_NAME=%q\n", o.Driver.Name)
 	o.Printer.DefaultText.Printf("HOST_ROOT=%q\n", o.Driver.HostRoot)
-
-	kr, err := driverkernel.FetchInfo("", "")
-	if err != nil {
-		return err
-	}
-
-	d, err := driverdistro.Discover(kr, o.Driver.HostRoot)
-	if err != nil {
-		if !errors.Is(err, driverdistro.ErrUnsupported) {
-			return err
-		}
-	}
-	o.Printer.DefaultText.Printf("TARGET_ID=%q\n", d.String())
-
-	o.Printer.DefaultText.Printf("ARCH=%q\n", kr.Architecture.ToNonDeb())
-	o.Printer.DefaultText.Printf("KERNEL_RELEASE=%q\n", kr.String())
-	o.Printer.DefaultText.Printf("KERNEL_VERSION=%q\n", kr.KernelVersion)
-
-	fixedKr := d.FixupKernel(kr)
+	o.Printer.DefaultText.Printf("TARGET_ID=%q\n", o.Distro.String())
+	o.Printer.DefaultText.Printf("ARCH=%q\n", o.Kr.Architecture.ToNonDeb())
+	o.Printer.DefaultText.Printf("KERNEL_RELEASE=%q\n", o.Kr.String())
+	o.Printer.DefaultText.Printf("KERNEL_VERSION=%q\n", o.Kr.KernelVersion)
+	fixedKr := o.Distro.FixupKernel(o.Kr)
 	o.Printer.DefaultText.Printf("FIXED_KERNEL_RELEASE=%q\n", fixedKr.String())
 	o.Printer.DefaultText.Printf("FIXED_KERNEL_VERSION=%q\n", fixedKr.KernelVersion)
-
 	return nil
 }

--- a/cmd/driver/printenv/printenv_test.go
+++ b/cmd/driver/printenv/printenv_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/falcosecurity/falcoctl/cmd"
 )
 
+//nolint:lll // no need to check for line length.
 var driverPrintenvHelp = `[Preview] Print variables used by driver as env vars.
 ** This command is in preview and under development. **
 
@@ -38,17 +39,19 @@ Flags:
   -h, --help   help for printenv
 
 Global Flags:
-      --config string       config file to be used for falcoctl (default "/etc/falcoctl/falcoctl.yaml")
-      --host-root string    Driver host root to be used. (default "/")
-      --log-format string   Set formatting for logs (color, text, json) (default "color")
-      --log-level string    Set level for logs (info, warn, debug, trace) (default "info")
-      --name string         Driver name to be used. (default "falco")
-      --repo strings        Driver repo to be used. (default [https://download.falco.org/driver])
-      --type string         Driver type to be used (auto, ebpf, kmod, modern_ebpf) (default "kmod")
-      --version string      Driver version to be used.
+      --config string          config file to be used for falcoctl (default "/etc/falcoctl/falcoctl.yaml")
+      --host-root string       Driver host root to be used. (default "/")
+      --kernelrelease string   Specify the kernel release for which to download/build the driver in the same format used by 'uname -r' (e.g. '6.1.0-10-cloud-amd64')
+      --kernelversion string   Specify the kernel version for which to download/build the driver in the same format used by 'uname -v' (e.g. '#1 SMP PREEMPT_DYNAMIC Debian 6.1.38-2 (2023-07-27)')
+      --log-format string      Set formatting for logs (color, text, json) (default "color")
+      --log-level string       Set level for logs (info, warn, debug, trace) (default "info")
+      --name string            Driver name to be used. (default "falco")
+      --repo strings           Driver repo to be used. (default [https://download.falco.org/driver])
+      --type strings           Driver types allowed in descending priority order (ebpf, kmod, modern_ebpf) (default [modern_ebpf,ebpf,kmod])
+      --version string         Driver version to be used.
 `
 
-var driverPrintenvDefaultConfig = `DRIVER="kmod"
+var driverPrintenvDefaultConfig = `DRIVER=".*"
 DRIVERS_REPO="https:\/\/download\.falco\.org\/driver"
 DRIVER_VERSION="1.0.0\+driver"
 DRIVER_NAME="falco"
@@ -116,8 +119,7 @@ var _ = Describe("printenv", func() {
 			BeforeEach(func() {
 				args = []string{driverCmd, printenvCmd, "--config", configFile, "--type", "foo", "--version", "1.0.0+driver"}
 			})
-			addAssertFailedBehavior(`ERROR invalid argument "foo" for "--type" flag: invalid argument "foo",` +
-				` please provide one of (auto, ebpf, kmod, modern_ebpf)`)
+			addAssertFailedBehavior(`unsupported driver type specified: foo`)
 		})
 	})
 

--- a/cmd/driver/printenv/printenv_test.go
+++ b/cmd/driver/printenv/printenv_test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 The Falco Authors
+// Copyright (C) 2024 The Falco Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,14 @@
 module github.com/falcosecurity/falcoctl
 
-go 1.21
+go 1.21.0
+
+toolchain go1.22.1
 
 require (
 	cloud.google.com/go/storage v1.39.1
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/blang/semver/v4 v4.0.0
+	github.com/cilium/ebpf v0.13.2
 	github.com/distribution/distribution/v3 v3.0.0-alpha.1
 	github.com/docker/cli v25.0.4+incompatible
 	github.com/docker/docker v25.0.4+incompatible

--- a/go.sum
+++ b/go.sum
@@ -210,6 +210,8 @@ github.com/chrismellard/docker-credential-acr-env v0.0.0-20230304212654-82a0ddb2
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
+github.com/cilium/ebpf v0.13.2 h1:uhLimLX+jF9BTPPvoCUYh/mBeoONkjgaJ9w9fn0mRj4=
+github.com/cilium/ebpf v0.13.2/go.mod h1:DHp1WyrLeiBh19Cf/tfiSMhqheEiK8fXFZ4No0P1Hso=
 github.com/clbanning/mxj/v2 v2.5.5/go.mod h1:hNiWqW14h+kc+MdF9C6/YoRfjEJoR3ou6tn/Qo+ve2s=
 github.com/clbanning/mxj/v2 v2.7.0 h1:WA/La7UGCanFe5NpHF0Q3DNtnCsVoxbPKuyBNHWRyME=
 github.com/clbanning/mxj/v2 v2.7.0/go.mod h1:hNiWqW14h+kc+MdF9C6/YoRfjEJoR3ou6tn/Qo+ve2s=
@@ -331,6 +333,8 @@ github.com/go-openapi/validate v0.22.4 h1:5v3jmMyIPKTR8Lv9syBAIRxG6lY0RqeBPB1LKE
 github.com/go-openapi/validate v0.22.4/go.mod h1:qm6O8ZIcPVdSY5219468Jv7kBdGvkiZLPOmqnqTUZ2A=
 github.com/go-piv/piv-go v1.11.0 h1:5vAaCdRTFSIW4PeqMbnsDlUZ7odMYWnHBDGdmtU/Zhg=
 github.com/go-piv/piv-go v1.11.0/go.mod h1:NZ2zmjVkfFaL/CF8cVQ/pXdXtuj110zEKGdJM6fJZZM=
+github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
+github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
 github.com/go-rod/rod v0.114.7 h1:h4pimzSOUnw7Eo41zdJA788XsawzHjJMyzCE3BrBww0=
 github.com/go-rod/rod v0.114.7/go.mod h1:aiedSEFg5DwG/fnNbUOTPMTTWX3MRj6vIs/a684Mthw=
 github.com/go-session/session v3.1.2+incompatible/go.mod h1:8B3iivBQjrz/JtC68Np2T1yBBLxTan3mn/3OM0CyRt0=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 The Falco Authors
+// Copyright (C) 2024 The Falco Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/driver/distro/cos.go
+++ b/pkg/driver/distro/cos.go
@@ -112,3 +112,20 @@ func (c *cos) customizeBuild(ctx context.Context,
 	}
 	return env, nil
 }
+
+// PreferredDriver is reimplemented since COS does not support kmod
+//
+//nolint:gocritic // the method shall not be able to modify kr
+func (c *cos) PreferredDriver(kr kernelrelease.KernelRelease, allowedDriverTypes []drivertype.DriverType) drivertype.DriverType {
+	for _, allowedDrvType := range allowedDriverTypes {
+		if allowedDrvType.String() == drivertype.TypeKmod {
+			continue
+		default:
+			break
+		}
+		if allowedDrvType.Supported(kr) {
+			return allowedDrvType
+		}
+	}
+	return nil
+}

--- a/pkg/driver/distro/cos.go
+++ b/pkg/driver/distro/cos.go
@@ -120,8 +120,6 @@ func (c *cos) PreferredDriver(kr kernelrelease.KernelRelease, allowedDriverTypes
 	for _, allowedDrvType := range allowedDriverTypes {
 		if allowedDrvType.String() == drivertype.TypeKmod {
 			continue
-		default:
-			break
 		}
 		if allowedDrvType.Supported(kr) {
 			return allowedDrvType

--- a/pkg/driver/distro/cos.go
+++ b/pkg/driver/distro/cos.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 The Falco Authors
+// Copyright (C) 2024 The Falco Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/driver/distro/distro.go
+++ b/pkg/driver/distro/distro.go
@@ -60,7 +60,7 @@ type Distro interface {
 	FixupKernel(kr kernelrelease.KernelRelease) kernelrelease.KernelRelease // private
 	customizeBuild(ctx context.Context, printer *output.Printer, driverType drivertype.DriverType,
 		kr kernelrelease.KernelRelease) (map[string]string, error)
-	PreferredDriver(kr kernelrelease.KernelRelease) drivertype.DriverType
+	PreferredDriver(kr kernelrelease.KernelRelease, allowedDriverTypes []drivertype.DriverType) drivertype.DriverType
 	fmt.Stringer
 }
 

--- a/pkg/driver/distro/distro.go
+++ b/pkg/driver/distro/distro.go
@@ -39,9 +39,10 @@ import (
 )
 
 const (
-	// DefaultFalcoRepo is the default repository provided by falcosecurity to download driver artifacts from.
 	kernelDirEnv            = "KERNELDIR"
 	kernelSrcDownloadFolder = "kernel-sources"
+	// UndeterminedDistro is the string used for the generic distro object returned when we cannot determine the distro.
+	UndeterminedDistro = "undetermined"
 )
 
 var (
@@ -93,7 +94,7 @@ func Discover(kr kernelrelease.KernelRelease, hostroot string) (Distro, error) {
 
 	// Return a generic distro to try the build
 	distro = &generic{}
-	if err = distro.init(kr, "undetermined", nil); err != nil {
+	if err = distro.init(kr, UndeterminedDistro, nil); err != nil {
 		return nil, err
 	}
 	return distro, ErrUnsupported

--- a/pkg/driver/distro/distro.go
+++ b/pkg/driver/distro/distro.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 The Falco Authors
+// Copyright (C) 2024 The Falco Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/driver/kernel/kernel_linux.go
+++ b/pkg/driver/kernel/kernel_linux.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 The Falco Authors
+// Copyright (C) 2024 The Falco Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,8 +40,11 @@ func FetchInfo(enforcedKR, enforcedKV string) (kernelrelease.KernelRelease, erro
 
 		kr = string(bytes.Trim(u.Release[:], "\x00"))
 		kv = string(bytes.Trim(u.Version[:], "\x00"))
-	} else {
+	}
+	if enforcedKR != "" {
 		kr = enforcedKR
+	}
+	if enforcedKV != "" {
 		kv = enforcedKV
 	}
 	kernelRel := kernelrelease.FromString(kr)

--- a/pkg/driver/kernel/kernel_linux.go
+++ b/pkg/driver/kernel/kernel_linux.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build linux
+
 // Package driverkernel implements the kernel info fetching helpers.
 package driverkernel
 

--- a/pkg/driver/kernel/kernel_others.go
+++ b/pkg/driver/kernel/kernel_others.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 The Falco Authors
+// Copyright (C) 2024 The Falco Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/driver/kernel/kernel_others.go
+++ b/pkg/driver/kernel/kernel_others.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !linux
+
+package driverkernel
+
+import (
+	"errors"
+
+	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
+)
+
+// FetchInfo returns information about currently running kernel.
+func FetchInfo(_, _ string) (kernelrelease.KernelRelease, error) {
+	return kernelrelease.KernelRelease{}, errors.New("unsupported")
+}

--- a/pkg/driver/type/bpf.go
+++ b/pkg/driver/type/bpf.go
@@ -74,6 +74,11 @@ func (b *bpf) HasArtifacts() bool {
 }
 
 //nolint:gocritic // the method shall not be able to modify kr
+func (b *bpf) Supported(kr kernelrelease.KernelRelease) bool {
+	return kr.SupportsProbe()
+}
+
+//nolint:gocritic // the method shall not be able to modify kr
 func (b *bpf) Build(ctx context.Context,
 	printer *output.Printer,
 	_ kernelrelease.KernelRelease,

--- a/pkg/driver/type/bpf.go
+++ b/pkg/driver/type/bpf.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 The Falco Authors
+// Copyright (C) 2024 The Falco Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/driver/type/kmod.go
+++ b/pkg/driver/type/kmod.go
@@ -165,6 +165,11 @@ func (k *kmod) HasArtifacts() bool {
 	return true
 }
 
+//nolint:gocritic // the method shall not be able to modify kr
+func (k *kmod) Supported(kr kernelrelease.KernelRelease) bool {
+	return kr.SupportsModule()
+}
+
 func createDKMSMakeFile(gcc string) error {
 	file, err := os.OpenFile("/tmp/falco-dkms-make", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o777) //nolint:gosec // we need the file to be executable
 	if err != nil {

--- a/pkg/driver/type/kmod.go
+++ b/pkg/driver/type/kmod.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 The Falco Authors
+// Copyright (C) 2024 The Falco Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/driver/type/modernbpf.go
+++ b/pkg/driver/type/modernbpf.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 The Falco Authors
+// Copyright (C) 2024 The Falco Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/driver/type/modernbpf.go
+++ b/pkg/driver/type/modernbpf.go
@@ -69,19 +69,16 @@ func (m *modernBpf) Supported(_ kernelrelease.KernelRelease) bool {
 	// Therefore, we need to manually build a feature test.
 	// Empty tracing program that just returns 0
 	progSpec := &ebpf.ProgramSpec{
-		Name:       "my_tracing_prog",
 		Type:       ebpf.Tracing,
 		AttachType: ebpf.AttachTraceRawTp,
 		AttachTo:   "sys_enter",
-		License:    "GPL",
 	}
 	err := probeProgram(progSpec)
 	if err != nil {
 		return false
 	}
 
-	err = features.HaveMapType(ebpf.RingBuf)
-	return err == nil
+	return features.HaveMapType(ebpf.RingBuf) == nil
 }
 
 //nolint:gocritic // the method shall not be able to modify kr

--- a/pkg/driver/type/type.go
+++ b/pkg/driver/type/type.go
@@ -25,9 +25,6 @@ import (
 	"github.com/falcosecurity/falcoctl/pkg/output"
 )
 
-// TypeAuto enables a smart automatic driver selection logic instead of using a fixed driver type.
-const TypeAuto = "auto"
-
 var driverTypes = map[string]DriverType{}
 
 // DriverType is the interface that wraps driver types.
@@ -39,6 +36,7 @@ type DriverType interface {
 	HasArtifacts() bool
 	Build(ctx context.Context, printer *output.Printer, kr kernelrelease.KernelRelease,
 		driverName, driverVersion string, env map[string]string) (string, error)
+	Supported(kr kernelrelease.KernelRelease) bool
 }
 
 // GetTypes return the list of supported driver types.
@@ -47,9 +45,6 @@ func GetTypes() []string {
 	for key := range driverTypes {
 		driverTypesSlice = append(driverTypesSlice, key)
 	}
-	// auto is a sentinel value to enable automatic driver selection logic,
-	// but it is not mapped to any DriverType
-	driverTypesSlice = append(driverTypesSlice, TypeAuto)
 	return driverTypesSlice
 }
 

--- a/pkg/driver/type/type.go
+++ b/pkg/driver/type/type.go
@@ -53,5 +53,5 @@ func Parse(driverType string) (DriverType, error) {
 	if dType, ok := driverTypes[driverType]; ok {
 		return dType, nil
 	}
-	return nil, fmt.Errorf("wrong driver type specified: %s", driverType)
+	return nil, fmt.Errorf("unsupported driver type specified: %s", driverType)
 }

--- a/pkg/driver/type/type.go
+++ b/pkg/driver/type/type.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 The Falco Authors
+// Copyright (C) 2024 The Falco Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/options/driver.go
+++ b/pkg/options/driver.go
@@ -36,7 +36,9 @@ func NewDriverTypes() *DriverTypes {
 	types := drivertype.GetTypes()
 	sort.Strings(types)
 	return &DriverTypes{
-		Enum: NewEnum(types, drivertype.TypeKmod),
+		// Default value is not used.
+		// This enum is only used to print allowed values.
+		Enum: NewEnum(types, drivertype.TypeModernBpf),
 	}
 }
 
@@ -52,7 +54,7 @@ type Driver struct {
 // ToDriverConfig maps a Driver options to Driver config struct.
 func (d *Driver) ToDriverConfig() *config.Driver {
 	return &config.Driver{
-		Type:     d.Type.String(),
+		Type:     []string{d.Type.String()},
 		Name:     d.Name,
 		Repos:    d.Repos,
 		Version:  d.Version,

--- a/pkg/options/driver.go
+++ b/pkg/options/driver.go
@@ -22,7 +22,10 @@ import (
 	"path/filepath"
 	"sort"
 
+	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
+
 	"github.com/falcosecurity/falcoctl/internal/config"
+	driverdistro "github.com/falcosecurity/falcoctl/pkg/driver/distro"
 	drivertype "github.com/falcosecurity/falcoctl/pkg/driver/type"
 )
 
@@ -49,6 +52,8 @@ type Driver struct {
 	Repos    []string
 	Version  string
 	HostRoot string
+	Distro   driverdistro.Distro
+	Kr       kernelrelease.KernelRelease
 }
 
 // ToDriverConfig maps a Driver options to Driver config struct.

--- a/pkg/options/driver.go
+++ b/pkg/options/driver.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 The Falco Authors
+// Copyright (C) 2024 The Falco Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
when a 
**Any specific area of the project related to this PR?**

/area library
/area cli

**What this PR does / why we need it**:

This PR expands the driver automatic selection logic, in this way:
* `--type` CLI option/`type` config key/`FALCOCTL_DRIVER_TYPE` env var do now support multiple driver types to be specified
* if a single `type` is specified, we retain the old behavior
* when multiple `type`s are passed, the automatic selection logic will choose the best-fit given:
  * types are passed in decreasing priority order
  * driver must be supported on the machine
 
New default is to enable all drivers in this order: `modern_ebpf,ebpf,kmod`.
`COS` target does now specialize `PreferredDriver` method since it does not support `kmod`.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
