### PR TITLE
chore(cmd,pkg,internal): switch to use `oras-go` credentials package since `oras-go-credentials` is deprecated

### DIFF
--- a/cmd/registry/auth/basic/basic.go
+++ b/cmd/registry/auth/basic/basic.go
@@ -19,8 +19,8 @@ import (
 	"context"
 	"fmt"
 
-	credentials "github.com/oras-project/oras-credentials-go"
 	"github.com/spf13/cobra"
+	"oras.land/oras-go/v2/registry/remote/credentials"
 
 	"github.com/falcosecurity/falcoctl/internal/config"
 	"github.com/falcosecurity/falcoctl/internal/login/basic"

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.32.0
 	github.com/opencontainers/image-spec v1.1.0
-	github.com/oras-project/oras-credentials-go v0.3.1
 	github.com/pterm/pterm v0.12.79
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sigstore/cosign/v2 v2.2.3

--- a/go.sum
+++ b/go.sum
@@ -616,8 +616,6 @@ github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQ
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
-github.com/oras-project/oras-credentials-go v0.3.1 h1:sfGqZ8sjPifEaOtjHOQTPr8D+Tql4bpw58Dd9wjmm9w=
-github.com/oras-project/oras-credentials-go v0.3.1/go.mod h1:fFCebDQo0Do+gnM96uV9YUnRay0pwuRQupypvofsp4s=
 github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
 github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml/v2 v2.1.1 h1:LWAJwfNvjQZCFIDKWYQaM62NcYeYViCmWIwmOStowAI=

--- a/internal/login/basic/basic.go
+++ b/internal/login/basic/basic.go
@@ -19,8 +19,8 @@ import (
 	"context"
 	"fmt"
 
-	credentials "github.com/oras-project/oras-credentials-go"
 	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/credentials"
 
 	"github.com/falcosecurity/falcoctl/pkg/oci/registry"
 )

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -18,9 +18,9 @@ package login
 import (
 	"context"
 
-	credentials "github.com/oras-project/oras-credentials-go"
 	"golang.org/x/oauth2/clientcredentials"
 	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/credentials"
 
 	"github.com/falcosecurity/falcoctl/internal/config"
 	"github.com/falcosecurity/falcoctl/internal/login/basic"

--- a/pkg/oci/authn/autologin.go
+++ b/pkg/oci/authn/autologin.go
@@ -18,8 +18,8 @@ package authn
 import (
 	"context"
 
-	credentials "github.com/oras-project/oras-credentials-go"
 	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/credentials"
 
 	"github.com/falcosecurity/falcoctl/internal/login"
 )

--- a/pkg/oci/authn/client.go
+++ b/pkg/oci/authn/client.go
@@ -21,8 +21,8 @@ import (
 	"net/http"
 	"time"
 
-	credentials "github.com/oras-project/oras-credentials-go"
 	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/credentials"
 )
 
 const (

--- a/pkg/oci/utils/utils.go
+++ b/pkg/oci/utils/utils.go
@@ -19,9 +19,9 @@ import (
 	"context"
 	"fmt"
 
-	credentials "github.com/oras-project/oras-credentials-go"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/credentials"
 
 	"github.com/falcosecurity/falcoctl/internal/config"
 	"github.com/falcosecurity/falcoctl/pkg/oci/authn"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area library

**What this PR does / why we need it**:

See https://github.com/oras-project/oras-credentials-go/discussions/80.
Since oras-go-credentials v0.4.0, it is advised to use oras-go `credentials` package instead of `oras-go-credentials` (that is now deprecated).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #419 

**Special notes for your reviewer**:
