### PR TITLE
fix(pkg/driver): fixup kernel headers download

### DIFF
--- a/pkg/driver/distro/distro.go
+++ b/pkg/driver/distro/distro.go
@@ -208,7 +208,12 @@ func Build(ctx context.Context,
 	// try to load kernel headers urls from driverkit.
 	if _, found := env[drivertype.KernelDirEnv]; !found {
 		printer.Logger.Debug("Trying to automatically fetch kernel headers.")
-		kernelHeadersPath, cleaner, err := loadKernelHeadersFromDk(d.String(), kr)
+		// KernelVersion needs to be fixed up; it is only used by driverkit Ubuntu builder
+		// and we must ensure that it is correctly set.
+		fixedKr := d.FixupKernel(kr)
+		kVerFixedKr := kr
+		kVerFixedKr.KernelVersion = fixedKr.KernelVersion
+		kernelHeadersPath, cleaner, err := loadKernelHeadersFromDk(d.String(), kVerFixedKr)
 		if cleaner != nil {
 			defer cleaner()
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

**Any specific area of the project related to this PR?**

/area library

**What this PR does / why we need it**:

This PR fixes the templating of kernel headers download script from driverkit, that needs a fixed up kernelversion (only ubuntu uses it in driverkit, and it must be actually fixed, so that eg: `#26~22.04.1 Ubuntu...`  becomes `26~22.04.1`).

~~Moreover, it bumps driverkit to what will become v0.18.2 that contains a fix for new KERNELDIR mechanism (https://github.com/falcosecurity/driverkit/pull/330).
`wip` until driverkit v0.18.2 is released.~~ Already in falcoctl main!

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
