### PR TITLE
fix(artifact/info): filter out signature tags

### DIFF
--- a/cmd/artifact/info/info.go
+++ b/cmd/artifact/info/info.go
@@ -99,7 +99,7 @@ func (o *artifactInfoOptions) RunArtifactInfo(ctx context.Context, args []string
 			return err
 		}
 
-		joinedTags := strings.Join(tags, ", ")
+		joinedTags := strings.Join(filterOutSigTags(tags), ", ")
 		data = append(data, []string{ref, joinedTags})
 	}
 
@@ -109,4 +109,15 @@ func (o *artifactInfoOptions) RunArtifactInfo(ctx context.Context, args []string
 	}
 
 	return nil
+}
+
+func filterOutSigTags(tags []string) []string {
+	// Iterate the slice in reverse to avoid index shifting when deleting
+	for i := len(tags) - 1; i >= 0; i-- {
+		if strings.HasSuffix(tags[i], ".sig") {
+			// Remove the element at index i by slicing the slice
+			tags = append(tags[:i], tags[i+1:]...)
+		}
+	}
+	return tags
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the Falco `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:
It does not print the signature tags for the artifacts.
Before:
```bash
❯ falcoctl artifact info k8saudit
REF                                             TAGS
ghcr.io/falcosecurity/plugins/plugin/k8saudit   latest, 0, 0.5, 0.5.0, 0.5.1, 0.5.2, 0.5.3, 0.6, 0.6.0, sha256-7081acb636b9017850a4cdea58c3ecf2cde09b426da21a72fdfb434d1ff8ba76.sig, sha256-2497cdd0531d8927b736729c4d891bbc61f451445f378ceef74f212675523894.sig, sha256-1ff068506c425d8d7651758ededf02c3c35834189265c4753ad674c87504048b.sig, sha256-7c7af9315ea63dabc6c6caeeea92c084f33a1ae674e1c1b6c6c9c3825bbf054f.sig, sha256-d8d90dee3e73d02a65d2681a34e7fc7e046e2010b7427eecd3e2bbecd576bf0e.sig, 0.6.1, sha256-230dfdc0e1d331c5085f3f4c860838dcfc27f9aca8d615ce7d771ace4b621dc6.sig, 0.7, 0.7.0, sha256-14ffc5b9992947db43043a998b1e62b954f25612af553ffb252df9e3324229b1.sig, main, sha256-e6484c99a85ab8c2fc77c4efbd2102a14ce4534cf7c12ad78c30a1a5e57d87ba.sig, sha256-8e00d4c3fbc557382ca53e5a61cd5bc3b32d1ef96f403d43c3990e5d0d3ccd84.sig, sha256-58415c8dab4f2a6d3a6af6dfbf432488c8ac6792c5820f8db9d34ae2f262e49a.sig, sha256-c787c173971de583d8dd530e4d9696cf77ef38f24379ac97f8e40d1142e0fada.sig, sha256-de5045c3c905a6d811a35dd06f60cb539e6c76aba62c8e59280441584e1d5db1.sig, sha256-e0231038d62720e3e4edf9801094ac069dd0a7a77966dd8b0ed3fbcc324a2c87.sig, sha256-ce4778b4c5c6aec65dd5ef0211cd769afb275b71a99c401bf59b18886232726a.sig, sha256-6d30ef6a09377782a1003341b3cdef01e5acea5841ef57d704471216a00e1f64.sig
```

After:
```bash
❯ falcoctl artifact info k8saudit
REF                                             TAGS
ghcr.io/falcosecurity/plugins/plugin/k8saudit   latest, 0, 0.5, 0.5.0, 0.5.1, 0.5.2, 0.5.3, 0.6, 0.6.0, 0.6.1, 0.7, 0.7.0, main
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
