### PR TITLE
fix: Add backend 'https' to default index

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -203,8 +203,9 @@ func init() {
 	IndexesDir = filepath.Join(FalcoctlPath, "indexes")
 	ClientCredentialsFile = filepath.Join(FalcoctlPath, "clientcredentials.json")
 	DefaultIndex = Index{
-		Name: "falcosecurity",
-		URL:  "https://falcosecurity.github.io/falcoctl/index.yaml",
+		Name:    "falcosecurity",
+		URL:     "https://falcosecurity.github.io/falcoctl/index.yaml",
+		Backend: "https",
 	}
 	DefaultDriver = Driver{
 		Type:     []string{drivertype.TypeModernBpf, drivertype.TypeBpf, drivertype.TypeKmod},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area cli

**What this PR does / why we need it**:

This PR will fix the issue #519 by adding the missing 'backend' field when generating the default configuration

old : 
```yaml
indexes:
    - name: falcosecurity
      url: https://falcosecurity.github.io/falcoctl/index.yaml
```
new: 
```yaml
indexes:
    - name: falcosecurity
      url: https://falcosecurity.github.io/falcoctl/index.yaml
      backend: "https"
```

**Which issue(s) this PR fixes**:

Fixes #519


huge thanks to the contributors to the Falco project and its ecosystem. 