### PR TITLE
add new boolean arg for 'registry push' --add-floating-tags, it will auto add the tags for the major and the minor versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ $ falcoctl registry push --type=plugin ghcr.io/falcosecurity/plugins/plugin/clou
 ```
 The type denotes the **artifact** type in this case *plugins*. The `ghcr.io/falcosecurity/plugins/plugin/cloudtrail:0.3.0` is the unique reference that points to the **artifact**.
 Currently, *falcoctl* supports only two types of artifacts: **plugin** and **rulesfile**. Based on **artifact type** the commands accepts different flags:
+* `--add-floating-tags`: add the floating tags for the major and minor versions
 * `--annotation-source`: set annotation source for the artifact;
 * `--depends-on`: set an artifact dependency (can be specified multiple times). Example: `--depends-on my-plugin:1.2.3`
 * `--tag`: additional artifact tag. Can be repeated multiple time 

--- a/cmd/registry/push/push.go
+++ b/cmd/registry/push/push.go
@@ -52,6 +52,10 @@ Example - Push artifact "myplugin.tar.gz" of type "plugin" for multiple platform
 Example - Push artifact "myrulesfile.tar.gz" of type "rulesfile":
 	falcoctl registry push --type rulesfile --version "0.1.2" localhost:5000/myrulesfile:latest myrulesfile.tar.gz
 
+Example - Push artifact "myrulesfile.tar.gz" of type "rulesfile" with floating tags for the major and minor versions (0 and 0.1):
+	falcoctl registry push --type rulesfile --version "0.1.2" localhost:5000/myrulesfile:latest myrulesfile.tar.gz \
+	        --add-floating-tags
+
 Example - Push artifact "myrulesfile.tar.gz" of type "rulesfile" to an insecure registry:
 	falcoctl registry push --type rulesfile --version "0.1.2" --plain-http localhost:5000/myrulesfile:latest myrulesfile.tar.gz
 
@@ -190,6 +194,14 @@ func (o *pushOptions) runPush(ctx context.Context, args []string) error {
 	}
 	if err := config.ParseRequirements(o.Requirements...); err != nil {
 		return err
+	}
+
+	if o.AutoFloatingTags {
+		v, err := semver.Parse(o.Version)
+		if err != nil {
+			return fmt.Errorf("expected semver for the flag \"--version\": %w", err)
+		}
+		o.Tags = append(o.Tags, o.Version, fmt.Sprintf("%v", v.Major), fmt.Sprintf("%v.%v", v.Major, v.Minor))
 	}
 
 	opts := ocipusher.Options{

--- a/cmd/registry/push/push_rulesfiles_test.go
+++ b/cmd/registry/push/push_rulesfiles_test.go
@@ -350,6 +350,21 @@ var _ = Describe("pushing rulesfiles", func() {
 				map[string]string{})
 		})
 
+		When("with add-floating-tags and the required flags", func() {
+			BeforeEach(func() {
+				rulesfile = rulesfileyaml
+				args = []string{registryCmd, pushCmd, fullRepoName, rulesfile, "--config", configFile, "--type", "rulesfile", "--version", version,
+					"--add-floating-tags", "--plain-http"}
+				// Set name to the expected one.
+				artifactNameInConfigLayer = repoName
+				// The semver tags are expected to be set.
+				pushedTags = []string{"1.1.1", "1.1", "1"}
+			})
+			AssertSuccesBehaviour([]oci.ArtifactDependency{},
+				[]oci.ArtifactRequirement{},
+				map[string]string{})
+		})
+
 		When("with full flags and args but in tar.gz format", func() {
 			BeforeEach(func() {
 				rulesfile = rulesfiletgz

--- a/pkg/options/artifact.go
+++ b/pkg/options/artifact.go
@@ -35,6 +35,7 @@ type Artifact struct {
 	Dependencies     []string
 	Requirements     []string
 	Tags             []string
+	AutoFloatingTags bool
 	AnnotationSource string
 }
 
@@ -63,6 +64,9 @@ func (art *Artifact) AddFlags(cmd *cobra.Command) error {
 	case "push":
 		cmd.Flags().StringArrayVarP(&art.Tags, "tag", "t", nil,
 			"additional artifact tag. Can be repeated multiple times")
+
+		cmd.Flags().BoolVar(&art.AutoFloatingTags, "add-floating-tags", false,
+			"add the floating tags for the major and minor versions")
 
 		cmd.Flags().Var(&art.ArtifactType, "type",
 			`type of artifact to be pushed. Allowed values: "rulesfile", "plugin", "asset"`)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the Falco `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

This PR introduces a new boolean arg for `registry push`: `--add-floating-tags`. If set, with `--version=1.2.3`, the tags `1` and `1.2` and `1.2.3` will be added automatically, it will make easier to follow the semver.

@alacuku do you think we should also add `latest` with that arg or another?

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
