### PR TITLE
chore(cmd/driver): remove redundant log.

### DIFF
--- a/cmd/driver/install/install.go
+++ b/cmd/driver/install/install.go
@@ -205,7 +205,6 @@ func (o *driverInstallOptions) RunDriverInstall(ctx context.Context) (string, er
 		}
 		buf.Reset()
 		if err == nil {
-			o.Printer.Logger.Info("Driver built.", o.Printer.Logger.Args("path", dest))
 			return dest, nil
 		}
 		if errors.Is(err, driverdistro.ErrAlreadyPresent) {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area cli

**What this PR does / why we need it**:

Both `driverkit` and `falcoctl` logs a successful driver build. Remove the redundant falcoctl log; see attached screenshot: 
![image](https://github.com/falcosecurity/falcoctl/assets/5837210/8a47c8db-4557-4362-b81f-520f73b7dda5)

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
