### PR TITLE
feat: Add --platform option to artifact/install

### DIFF
--- a/cmd/artifact/install/constants.go
+++ b/cmd/artifact/install/constants.go
@@ -19,6 +19,9 @@ const (
 	// FlagAllowedTypes is the name of the flag to specify allowed artifact types.
 	FlagAllowedTypes = "allowed-types"
 
+	// FlagPlatform is the name of the flag to override the platform.
+	FlagPlatform = "platform"
+
 	// FlagResolveDeps is the name of the flag to enable artifact dependencies resolution.
 	FlagResolveDeps = "resolve-deps"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the Falco `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

/area cli

**What this PR does / why we need it**:

This PR adds a `--platform` CLI option to the `artifact install` command.

For example: `falcoctl artifact install --platform linux/amd64 ...`

There are various other commands that accept a `--platform` argument so I implemented this in the same way.

Reason: We are deploying Falco into environments that may be air gapped so we want to produce a single OCI image with the appropriate rule sets and plugins. We want to use `falcoctl` to download the artifacts. However, this always downloads the artifacts for the architecture that the CI system (or developer laptop) is running, and this often produces errors, e.g. "unable to find a manifest matching the given platform: darwin/arm64". With this new option it's possible to specify `--platform=linux/amd64` and have this work even on an ARM build host or a local mac environment.

Additionally, when I was building this, I noticed that the tests for `artifact install` were failing on my local Mac machine, so I added this new `--platform` CLI flag to the tests that were failing so it would align with the `linux/amd64` that is hard-coded elsewhere in the test. I marked this as solving a failing test for that reason.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

N/A