### PR TITLE
feat: Add file backend to fetcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Indices for *falcoctl* can be retrieved from various storage backends. The suppo
 | http  | http://    | Can be used to retrieve indices via simple HTTP GET requests.                                 |
 | https | https://   | Convenience alias for the HTTP backend.                                                       |
 | gcs   | gs://      | For indices stored as Google Cloud Storage objects. Supports application default credentials. |
+| file  | file://    | For indices stored on the local file system.                                                  |
 
 
 #### falcoctl index add

--- a/pkg/index/fetch/fetch.go
+++ b/pkg/index/fetch/fetch.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/falcosecurity/falcoctl/pkg/index/config"
+	"github.com/falcosecurity/falcoctl/pkg/index/fetch/file"
 	"github.com/falcosecurity/falcoctl/pkg/index/fetch/gcs"
 	"github.com/falcosecurity/falcoctl/pkg/index/fetch/http"
 	"github.com/falcosecurity/falcoctl/pkg/index/index"
@@ -46,11 +47,13 @@ func NewFetcher() *Fetcher {
 			"http":  http.Fetch,
 			"https": http.Fetch,
 			"gcs":   gcs.Fetch,
+			"file":  file.Fetch,
 		},
 		schemeDefaultBackends: map[string]string{
 			"http":  "http",
 			"https": "https",
 			"gs":    "gcs",
+			"file":  "file",
 		},
 	}
 }

--- a/pkg/index/fetch/file/doc.go
+++ b/pkg/index/fetch/file/doc.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package file implements all the logic for fetching indexes from the local file system.
+package file

--- a/pkg/index/fetch/file/fetcher.go
+++ b/pkg/index/fetch/file/fetcher.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	"context"
+	"fmt"
+	pkgurl "net/url"
+	"os"
+
+	"github.com/falcosecurity/falcoctl/pkg/index/config"
+)
+
+// Fetch fetches the raw index file from the local file system.
+func Fetch(_ context.Context, conf *config.Entry) ([]byte, error) {
+	// Expect URL to be file:///some/directory/filename.yaml
+	url, err := pkgurl.Parse(conf.URL)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse URL: %w", err)
+	}
+
+	data, err := os.ReadFile(url.Path)
+	if err != nil {
+		return nil, fmt.Errorf("reading file: %w", err)
+	}
+
+	return data, nil
+}

--- a/pkg/index/fetch/file/fetcher_test.go
+++ b/pkg/index/fetch/file/fetcher_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+
+	"github.com/falcosecurity/falcoctl/pkg/index/config"
+	"github.com/falcosecurity/falcoctl/pkg/index/index"
+)
+
+func TestFileFetchWithValidFile(t *testing.T) {
+	filename := "TestFileFetchWithValidFile-filename.yaml"
+	entries := []index.Entry{{
+		Name:       "test",
+		Type:       "rulesfile",
+		Registry:   "test.io",
+		Repository: "test",
+		Maintainers: index.Maintainer{
+			{
+				Email: "test@local",
+				Name:  "test",
+			},
+		},
+		Sources:  []string{"/test"},
+		Keywords: []string{"test"},
+	}}
+
+	ctx := context.Background()
+
+	configDir := t.TempDir()
+	configFile := filepath.Join(configDir, filename)
+
+	entryBytes, err := yaml.Marshal(entries)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	err = os.WriteFile(configFile, entryBytes, os.FileMode(0o644))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	b, err := Fetch(ctx, &config.Entry{
+		Name:    "test",
+		URL:     fmt.Sprintf("file://%s/%s", configDir, filename),
+		Backend: "GCS",
+	})
+
+	assert.NoError(t, err, "error should not occur")
+	assert.NotNil(t, b, "returned bytes should not be nil")
+	var resultEntries []index.Entry
+	err = yaml.Unmarshal(b, &resultEntries)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	assert.Equal(t, entries, resultEntries)
+}
+
+func TestFileFetchWithNonExistentFile(t *testing.T) {
+	filename := "TestFileFetchWithNonExistentFile-filename.yaml"
+
+	ctx := context.Background()
+
+	configDir := t.TempDir()
+	// We intentionally do not write out the file here
+
+	_, err := Fetch(ctx, &config.Entry{
+		Name:    "test",
+		URL:     fmt.Sprintf("file://%s/%s", configDir, filename),
+		Backend: "GCS",
+	})
+
+	expectedError := fmt.Sprintf("reading file: open %s/%s: no such file or directory", configDir, filename)
+	assert.EqualError(t, err, expectedError)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the Falco `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

**What this PR does / why we need it**:

This PR adds a "local file" storage backend for the index file.

To keep consistent with the existing design, this is specified by `file:///some/directory/my-index.yaml` which allows the existing code to correctly guess the storage backend.

I wrote a test covering the new backend as well.

Reason we need this: We want to use `falcoctl` in environments to help build configuration artifacts in environments that may not have internet access, so a local file works better for us.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
