### PR TITLE
new(cmd/driver): driver config namespace from env variable

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -136,7 +136,9 @@ const (
 	// DriverNameKey is the Viper key for the driver name.
 	DriverNameKey = "driver.name"
 	// DriverHostRootKey is the Viper key for the driver host root.
-	DriverHostRootKey   = "driver.hostRoot"
+	DriverHostRootKey = "driver.hostRoot"
+	// DriverNamespaceKey is the Viper key for the driver config namespace flag.
+	DriverNamespaceKey  = "driver.config.namespace"
 	falcoHostRootEnvKey = "HOST_ROOT"
 )
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

**Any specific area of the project related to this PR?**

/area cli

**What this PR does / why we need it**:

This PR enables the `namespace` parameter of `driver config` command to be passed as `FALCOCTL_DRIVER_CONFIG_NAMESPACE` env variable.

Also, it fixes k8s configMap commit code, switching from `Patch` to `Update` command.
Finally, logs are a little improved.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
