### PR TITLE
chore(pkg/driver): restored `uek` kernel check.

### DIFF
--- a/pkg/driver/distro/distro_test.go
+++ b/pkg/driver/distro/distro_test.go
@@ -168,6 +168,28 @@ func TestDiscoverDistro(t *testing.T) {
 			errExpected:    false,
 		},
 		{
+			// os-release ID "ol" maps to oracle
+			krInput: "5.10.0-2047.510.5.5.el7uek.x86_64",
+			preFn: func() error {
+				type brCfg struct {
+					OsID string `ini:"ID"`
+				}
+				f := ini.Empty()
+				err := f.ReflectFrom(&brCfg{
+					OsID: "ol",
+				})
+				if err != nil {
+					return err
+				}
+				return f.SaveTo(osReleaseFile)
+			},
+			postFn: func() {
+				_ = os.Remove(osReleaseFile)
+			},
+			distroExpected: &ol{},
+			errExpected:    false,
+		},
+		{
 			// No os-release  but "centos-release" file present maps to centos
 			krInput: "5.10.0",
 			preFn: func() error {

--- a/pkg/driver/distro/oracle.go
+++ b/pkg/driver/distro/oracle.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package driverdistro
+
+import (
+	"strings"
+
+	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
+
+	drivertype "github.com/falcosecurity/falcoctl/pkg/driver/type"
+)
+
+func init() {
+	distros["ol"] = &ol{generic: &generic{}}
+}
+
+type ol struct {
+	*generic
+}
+
+//nolint:gocritic // the method shall not be able to modify kr
+func (o *ol) PreferredDriver(kr kernelrelease.KernelRelease, allowedDriverTypes []drivertype.DriverType) drivertype.DriverType {
+	for _, allowedDrvType := range allowedDriverTypes {
+		// Skip dkms on UEK hosts because it will always fail
+		if allowedDrvType.String() == drivertype.TypeKmod && strings.Contains(kr.String(), "uek") {
+			continue
+		}
+		if allowedDrvType.Supported(kr) {
+			return allowedDrvType
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

**Any specific area of the project related to this PR?**

/area library

**What this PR does / why we need it**:

https://github.com/falcosecurity/falcoctl/pull/356 removed a check about `uek` kernels while building kmod: https://github.com/falcosecurity/falcoctl/pull/356/files#diff-5f5269945d03266c023f8eff0f114f39d68d0fec1bcc9b57f386e309630f9db9L186.
This PR restores the check by avoiding to allow `kmod` type for `uek` kernels.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
