### PR TITLE
wip: new(cmd/driver): download compatible driver version if requested

### DIFF
--- a/cmd/driver/install/install.go
+++ b/cmd/driver/install/install.go
@@ -225,7 +225,7 @@ func (o *driverInstallOptions) RunDriverInstall(ctx context.Context) (string, er
 			}
 
 			if currDrvVer != o.Driver.Version {
-				o.Printer.Logger.Info("Using compatible driver version",
+				o.Printer.Logger.Info("Using compatible driver",
 					o.Printer.Logger.Args("version", currDrvVer))
 			} else {
 				o.Printer.Logger.Debug("No compatible driver version found, fallback at configured one")

--- a/cmd/driver/install/install.go
+++ b/cmd/driver/install/install.go
@@ -171,6 +171,10 @@ func (o *driverInstallOptions) RunDriverInstall(ctx context.Context) (string, er
 		if o.Compatible {
 			o.Printer.Logger.Debug("Loading compatible driver version from S3")
 
+			if !semver.IsValid("v" + currDrvVer) {
+				o.Printer.Logger.Debug("Running a development driver version. Cannot determine compatible versions.")
+			}
+
 			bucket := "falco-distribution"
 			region := "eu-west-1"
 
@@ -212,8 +216,8 @@ func (o *driverInstallOptions) RunDriverInstall(ctx context.Context) (string, er
 
 					// Step 3: find the highest driver version compatible with configured one
 					for _, dVer := range driverVersions {
-						if semver.Compare(dVer, currDrvVer) > 0 &&
-							semver.Major(dVer) == semver.Major(currDrvVer) {
+						if semver.Compare("v"+dVer, "v"+currDrvVer) > 0 &&
+							semver.Major("v"+dVer) == semver.Major("v"+currDrvVer) {
 							currDrvVer = dVer
 						}
 					}

--- a/cmd/driver/install/install_test.go
+++ b/cmd/driver/install/install_test.go
@@ -32,6 +32,7 @@ Usage:
   falcoctl driver install [flags]
 
 Flags:
+      --compatible              Whether to enable download of latest compatible driver version instead of the configured one
       --compile                 Whether to enable local compilation of drivers (default true)
       --download                Whether to enable download of prebuilt drivers (default true)
   -h, --help                    help for install

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.22.2
 
 require (
 	cloud.google.com/go/storage v1.41.0
+	github.com/aws/aws-sdk-go v1.51.31
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/blang/semver/v4 v4.0.0
 	github.com/cilium/ebpf v0.15.0
@@ -34,6 +35,7 @@ require (
 	github.com/spf13/viper v1.18.2
 	golang.org/x/crypto v0.23.0
 	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842
+	golang.org/x/mod v0.17.0
 	google.golang.org/api v0.181.0
 	gopkg.in/ini.v1 v1.67.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -321,7 +323,6 @@ require (
 	go.step.sm/crypto v0.44.8 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
-	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/text v0.15.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/tools v0.21.0 // indirect


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area cli

**What this PR does / why we need it**:

This small patch allows to download compatible driver versions instead of the currently configured one.
This is how it works:
* you have falco 0.37.1 installed that ships with driver 7.0.0+driver
* you run `falcoctl driver install --compatible`
* it lists prefixes on our s3 bucket under the driver/ prefix (https://download.falco.org/driver/)
* loads all semver-like driver versions
* fetches the newest compatible one (where compatible in this context means same major version)
* this means that for Falco 0.37.1 it would download driver 7.2.0+driver.

Now, we cannot do the same for the compilation because we have only local sources for the driver installed Falco was shipped with, but that's not a big deal for now. We could have a post-submit job triggered whenever a new driver version is added (https://github.com/falcosecurity/test-infra/tree/master/driverkit/config) that push driver sources configured for Falco under eg: https://download.falco.org/driver/$version/src/.

Disabled by default for now.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Keeping it as `wip` until we decide what to do for compilation too.