### PR TITLE
fix: allow login to express registry as ref but actually extract the …

### DIFF
--- a/cmd/registry/auth/basic/basic.go
+++ b/cmd/registry/auth/basic/basic.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/falcosecurity/falcoctl/internal/config"
 	"github.com/falcosecurity/falcoctl/internal/login/basic"
+	"github.com/falcosecurity/falcoctl/internal/utils"
 	"github.com/falcosecurity/falcoctl/pkg/oci/authn"
 	"github.com/falcosecurity/falcoctl/pkg/options"
 	"github.com/falcosecurity/falcoctl/pkg/output"
@@ -95,8 +96,15 @@ Example - Login with username and password in an interactive prompt:
 
 // RunBasic executes the business logic for the basic command.
 func (o *loginOptions) RunBasic(ctx context.Context, args []string) error {
-	reg := args[0]
+	var reg string
 	logger := o.Printer.Logger
+
+	// Allow to have the registry expressed as a ref, but actually extract it.
+	reg, err := utils.GetRegistryFromRef(args[0])
+	if err != nil {
+		reg = args[0]
+	}
+
 	if err := getCredentials(o.Printer, o); err != nil {
 		return err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/viper"
 
+	"github.com/falcosecurity/falcoctl/internal/utils"
 	drivertype "github.com/falcosecurity/falcoctl/pkg/driver/type"
 	"github.com/falcosecurity/falcoctl/pkg/oci"
 )
@@ -395,8 +396,14 @@ func basicAuthListHookFunc() mapstructure.DecodeHookFuncType {
 					return data, fmt.Errorf("not valid token %q", token)
 				}
 
+				// Allow to have the registry expressed as a ref, but actually extract it.
+				registry, err := utils.GetRegistryFromRef(values[0])
+				if err != nil {
+					registry = values[0]
+				}
+
 				auths[i] = BasicAuth{
-					Registry: values[0],
+					Registry: registry,
 					User:     values[1],
 					Password: values[2],
 				}


### PR DESCRIPTION
…registry

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the Falco `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:
As per PR title, allow to login with the entire ref, but actually just use the registry (pretty much like how docker login works). 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
