### PR TITLE
fix(push): use basename for artifacts when compressed in tar.gz

### DIFF
--- a/cmd/registry/push/push.go
+++ b/cmd/registry/push/push.go
@@ -174,7 +174,7 @@ func (o *pushOptions) runPush(ctx context.Context, args []string) error {
 					return err
 				}
 			}
-			path, err := utils.CreateTarGzArchive("", p)
+			path, err := utils.CreateTarGzArchive("", p, true)
 			if err != nil {
 				return err
 			}

--- a/internal/utils/compress_test.go
+++ b/internal/utils/compress_test.go
@@ -40,7 +40,7 @@ func TestCreateTarGzArchiveFile(t *testing.T) {
 	}
 	defer f1.Close()
 
-	tarball, err := CreateTarGzArchive(tmpPrefix, filepath.Join(dir, filename1))
+	tarball, err := CreateTarGzArchive(tmpPrefix, filepath.Join(dir, filename1), false)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -67,6 +67,41 @@ func TestCreateTarGzArchiveFile(t *testing.T) {
 	}
 }
 
+func TestCreateTarGzArchiveFileStripComponents(t *testing.T) {
+	dir := t.TempDir()
+	f1, err := os.Create(filepath.Join(dir, filename1))
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	defer f1.Close()
+
+	tarball, err := CreateTarGzArchive(tmpPrefix, filepath.Join(dir, filename1), true)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	defer os.RemoveAll(filepath.Dir(tarball))
+
+	file, err := os.Open(tarball)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	paths, err := listHeaders(file)
+	fmt.Println(paths)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if len(paths) != 1 {
+		t.Fatalf("Expected 1 path, got %d", len(paths))
+	}
+
+	base := paths[0]
+	if base != filename1 {
+		t.Errorf("Expected file1, got %s", base)
+	}
+}
+
 func TestCreateTarGzArchiveDir(t *testing.T) {
 	// Test that we can compress directories
 	dir := t.TempDir()
@@ -83,7 +118,7 @@ func TestCreateTarGzArchiveDir(t *testing.T) {
 	}
 	defer f2.Close()
 
-	tarball, err := CreateTarGzArchive(tmpPrefix, dir)
+	tarball, err := CreateTarGzArchive(tmpPrefix, dir, false)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/pkg/driver/type/modernbpf.go
+++ b/pkg/driver/type/modernbpf.go
@@ -16,8 +16,7 @@
 package drivertype
 
 import (
-	// Needed for go:linkname to be able to access a private function from cilium/ebpf/features.
-	_ "unsafe"
+	_ "unsafe" // Needed for go:linkname to be able to access a private function from cilium/ebpf/features.
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/features"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the Falco `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

 /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area library

/area cli

 /area tests

> /area examples

**What this PR does / why we need it**:

A `registry push` command like:
```
falcoctl registry push
   --type plugin --version 0.1.1 
   --requires plugin_api_version:3.1.0 
   --platform linux/amd64
   ghcr.io/alacuku/plugins/plugin/k8smeta:0.1.1 
   /home/aldo/Downloads/libk8smeta.so 
```
works fine, but when we try to install that artifact we get the following:

```
falcoctl artifact install ghcr.io/alacuku/plugins/plugin/k8smeta:0.1.1
2024-07-24 15:57:15 INFO  Resolving dependencies ... 
2024-07-24 15:57:16 INFO  Installing artifacts refs: [ghcr.io/alacuku/plugins/plugin/k8smeta:0.1.1]
2024-07-24 15:57:16 INFO  Preparing to pull artifact ref: ghcr.io/alacuku/plugins/plugin/k8smeta:0.1.1
2024-07-24 15:57:17 INFO  Pulling layer bb550464b415 
2024-07-24 15:57:17 INFO  Pulling layer 17c172171107                                                                                                                                                                                                                                                                                                                                                                              
2024-07-24 15:57:20 INFO  Pulling layer 6864efe49a85                                                                                                                                                                                                                                                                                                                                                                              
2024-07-24 15:57:20 INFO  Extracting and installing artifact type: plugin file: libk8smeta.tar.gz                                                                                                                                                                                                                                                                                                                                 
2024-07-24 15:57:20 ERROR cannot extract "/tmp/falcoctl4200489493/libk8smeta.tar.gz" to "/usr/share/falco/plugins": open                                                                                                                                                                                                                                                                                                          
                      │   /usr/share/falco/plugins/home/aldo/Downloads/libk8smeta.so: no such file or directory

```

The reason is that the tar header in the archive is the file path, in this case `home/aldo/Downloads/libk8smeta.so`. This PR ensures we use only the base name as a header in the tar archive, hence striping the components from the file path.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
