### PR TITLE
fix(auth/basic): bind pflags to viper only when required

### DIFF
--- a/cmd/registry/auth/basic/basic.go
+++ b/cmd/registry/auth/basic/basic.go
@@ -69,6 +69,10 @@ Example - Login with username and password in an interactive prompt:
 `,
 		Args: cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			_ = viper.BindPFlag("registry.auth.basic.username", cmd.Flags().Lookup("username"))
+			_ = viper.BindPFlag("registry.auth.basic.password", cmd.Flags().Lookup("password"))
+			_ = viper.BindPFlag("registry.auth.basic.password_stdin", cmd.Flags().Lookup("password-stdin"))
+
 			o.username = viper.GetString("registry.auth.basic.username")
 			o.password = viper.GetString("registry.auth.basic.password")
 			o.passwordFromStdin = viper.GetBool("registry.auth.basic.password_stdin")
@@ -83,13 +87,6 @@ Example - Login with username and password in an interactive prompt:
 	cmd.Flags().StringVarP(&o.username, "username", "u", "", "registry username")
 	cmd.Flags().StringVarP(&o.password, "password", "p", "", "registry password")
 	cmd.Flags().BoolVar(&o.passwordFromStdin, "password-stdin", false, "read password from stdin")
-
-	_ = viper.BindPFlag("registry.auth.basic.username", cmd.Flags().Lookup("username"))
-	_ = viper.BindPFlag("registry.auth.basic.password", cmd.Flags().Lookup("password"))
-	_ = viper.BindPFlag("registry.auth.basic.password_stdin", cmd.Flags().Lookup("password-stdin"))
-
-	// Bind to environment variables.
-	viper.AutomaticEnv()
 
 	return cmd
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the Falco `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

Binding pflags to Viper too early will generate a faulty configuration file for falcoctl. This commit ensures binding is done only when the basic authentication command is called.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
