### PR TITLE
update(go,pkg): updated driverkit to v0.20.3.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/distribution/distribution/v3 v3.0.0-alpha.1
 	github.com/docker/cli v27.0.2+incompatible
 	github.com/docker/docker v27.1.1+incompatible
-	github.com/falcosecurity/driverkit v0.20.0
+	github.com/falcosecurity/driverkit v0.20.3
 	github.com/go-oauth2/oauth2/v4 v4.5.2
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/go-containerregistry v0.19.2

--- a/go.sum
+++ b/go.sum
@@ -317,8 +317,8 @@ github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lSh
 github.com/evanphx/json-patch v5.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2Wvf/TIe2xdyJxTlb6obmF18d8QdkxNDu4=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f/go.mod h1:OSYXu++VVOHnXeitef/D8n/6y4QV8uLHSFXX4NeXMGc=
-github.com/falcosecurity/driverkit v0.20.0 h1:JK95yA9JIIfuyRYhDq+eOvOU/PIcbiF0h91sbRHrhek=
-github.com/falcosecurity/driverkit v0.20.0/go.mod h1:jAfMal2CLnkGV0hAbOP0DEisOMqubbwfs7IcVu3H1Y0=
+github.com/falcosecurity/driverkit v0.20.3 h1:WCys2uMiaTnhgnAwaX8DQBYHGhHyciBsvWL9+wWGh7s=
+github.com/falcosecurity/driverkit v0.20.3/go.mod h1:xFecEFc9v8uMx1oI+6LJEEYrqX85r0dpNVsARUmrNNU=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=

--- a/pkg/driver/distro/cos.go
+++ b/pkg/driver/distro/cos.go
@@ -69,7 +69,7 @@ func (c *cos) customizeBuild(ctx context.Context,
 	}
 	printer.Logger.Info("COS detected, using COS kernel headers.", printer.Logger.Args("build ID", c.buildID))
 	bpfKernelSrcURL := fmt.Sprintf("https://storage.googleapis.com/cos-tools/%s/kernel-headers.tgz", c.buildID)
-	kr.Extraversion = "+"
+
 	env, err := downloadKernelSrc(ctx, printer, &kr, bpfKernelSrcURL, 0)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area library

**What this PR does / why we need it**:

Moreover, removed useless line in cos distro.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Driverkit v0.20.3 contains a fix for the kernelrelease regex (https://github.com/falcosecurity/driverkit/pull/355) that will fix COS kernelreleases (eg: `5.10.8+`) being failed to be matched and thus remaining empty (https://github.com/falcosecurity/falco/issues/3278).
