### PR TITLE
Added authentication functionality for the private index.

### DIFF
--- a/cmd/index/add/add.go
+++ b/cmd/index/add/add.go
@@ -38,11 +38,11 @@ func NewIndexAddCmd(ctx context.Context, opt *options.Common) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "add [NAME] [URL] [BACKEND] [flags]",
+		Use:                   "add [NAME] [URL] [BACKEND] [TOKEN] [flags]",
 		DisableFlagsInUseLine: true,
 		Short:                 "Add an index to the local falcoctl configuration",
-		Long:                  "Add an index to the local falcoctl configuration. Indexes are used to perform search operations for artifacts",
-		Args:                  cobra.RangeArgs(2, 3),
+		Long:                  "Add an index to the local falcoctl configuration. Indexes are used to perform search operations for artifacts\nIf you need authentication for using private index. You have to use token ( base64 encode \"HeaderName:Token\" )",
+		Args:                  cobra.RangeArgs(2, 4),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.RunIndexAdd(ctx, args)
 		},
@@ -59,8 +59,11 @@ func (o *IndexAddOptions) RunIndexAdd(ctx context.Context, args []string) error 
 	name := args[0]
 	url := args[1]
 	backend := ""
-	if len(args) > 2 {
+	token := ""
+	if len(args) == 3 {
 		backend = args[2]
+	} else if len(args) == 4 {
+		token = args[3]
 	}
 
 	logger.Debug("Creating in-memory cache using", logger.Args("indexes file", config.IndexesFile, "indexes directory", config.IndexesDir))
@@ -71,7 +74,7 @@ func (o *IndexAddOptions) RunIndexAdd(ctx context.Context, args []string) error 
 
 	logger.Info("Adding index", logger.Args("name", name, "path", url))
 
-	if err = indexCache.Add(ctx, name, backend, url); err != nil {
+	if err = indexCache.Add(ctx, name, backend, url, token); err != nil {
 		return fmt.Errorf("unable to add index: %w", err)
 	}
 

--- a/cmd/index/add/add_test.go
+++ b/cmd/index/add/add_test.go
@@ -27,7 +27,7 @@ import (
 
 //nolint:lll // no need to check for line length.
 var indexAddUsage = `Usage:
-falcoctl index add [NAME] [URL] [BACKEND] [flags]
+falcoctl index add [NAME] [URL] [BACKEND] [TOKEN] [flags]
 
 Flags:
 -h, --help   help for add
@@ -42,7 +42,7 @@ Global Flags:
 var indexAddHelp = `Add an index to the local falcoctl configuration. Indexes are used to perform search operations for artifacts
 
 Usage:
-  falcoctl index add [NAME] [URL] [BACKEND] [flags]
+  falcoctl index add [NAME] [URL] [BACKEND] [TOKEN] [flags]
 
 Flags:
   -h, --help   help for add
@@ -97,7 +97,7 @@ var indexAddTests = Describe("add", func() {
 			BeforeEach(func() {
 				args = []string{indexCmd, addCmd, "--config", configFile, indexName}
 			})
-			addAssertFailedBehavior(indexAddUsage, "ERROR accepts between 2 and 3 arg(s), received 1")
+			addAssertFailedBehavior(indexAddUsage, "ERROR accepts between 2 and 4 arg(s), received 1")
 		})
 
 		When("with invalid URL", func() {

--- a/pkg/index/cache/cache.go
+++ b/pkg/index/cache/cache.go
@@ -134,7 +134,7 @@ func NewFromConfig(ctx context.Context, indexFile, indexesDir string, indexes []
 // Add adds a new index file to the cache. If the index file already exists in the cache it
 // does nothing. On the other hand, it fetches the index file using the provided URL and adds
 // it to the in memory cache. It does not write it to the filesystem. It is idempotent.
-func (c *Cache) Add(ctx context.Context, name, backend, url string) error {
+func (c *Cache) Add(ctx context.Context, name, backend, url, token string) error {
 	var remoteIndex *index.Index
 	var err error
 
@@ -149,6 +149,7 @@ func (c *Cache) Add(ctx context.Context, name, backend, url string) error {
 		Name:    name,
 		URL:     url,
 		Backend: backend,
+		Token:   token,
 	}
 
 	// If the index is not locally cached we fetch it using the provided url.
@@ -164,6 +165,7 @@ func (c *Cache) Add(ctx context.Context, name, backend, url string) error {
 		UpdatedTimestamp: ts,
 		URL:              url,
 		Backend:          backend,
+		Token:            token,
 	}
 	c.localIndexes.Add(entry)
 

--- a/pkg/index/config/config.go
+++ b/pkg/index/config/config.go
@@ -33,6 +33,7 @@ type Entry struct {
 	UpdatedTimestamp string `yaml:"updated_timestamp"`
 	URL              string `yaml:"url"`
 	Backend          string `yaml:"backend"`
+	Token            string `yaml:"token"`
 	// TODO: add support for HTTP and other backend configs.
 	// HTTP             http.BackendConfig `yaml:"http"`
 }

--- a/pkg/index/fetch/http/fetcher.go
+++ b/pkg/index/fetch/http/fetcher.go
@@ -17,9 +17,11 @@ package http
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/falcosecurity/falcoctl/pkg/index/config"
 )
@@ -29,6 +31,15 @@ func Fetch(ctx context.Context, conf *config.Entry) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", conf.URL, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("cannot fetch index: %w", err)
+	}
+
+	if conf.Token != "" {
+		tokenString, err := base64.StdEncoding.DecodeString(conf.Token)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse index token: %w", err)
+		}
+		indexToken := strings.Split(string(tokenString), ":")
+		req.Header.Add(indexToken[0], indexToken[1])
 	}
 
 	client := &http.Client{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the Falco `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

> /area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

I have added authentication functionality for the private index.
When I use private index on Enterprise Github environment (Internal/Private Repository), Exsisted Version's falcoctl is not supported.

```bash
> falcoctl index add private_index https://raw.enterprise-github.com/org_name/repo_name/main/index.yaml https {{ base64.encode("Header_name:Authentication_token") }}
``` 
