### PR TITLE
fix(cmd): relax file perms for Falco driver config override

### DIFF
--- a/cmd/driver/config/config.go
+++ b/cmd/driver/config/config.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 The Falco Authors
+// Copyright (C) 2024 The Falco Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -238,7 +238,8 @@ func overwriteDriverType(configDir string, driverType drivertype.DriverType) err
 	_, err := os.Stat(configDir)
 	if os.IsNotExist(err) {
 		// Create it.
-		if err := os.MkdirAll(configDir, 0o750); err != nil {
+		// #nosec G301 -- under /etc we want 755 permissions
+		if err := os.MkdirAll(configDir, 0o755); err != nil {
 			return fmt.Errorf("unable to create directory %s: %w", configDir, err)
 		}
 	} else if err != nil && !os.IsNotExist(err) {
@@ -252,7 +253,8 @@ func overwriteDriverType(configDir string, driverType drivertype.DriverType) err
 	}
 
 	// Write the engine configuration to a specialized config file.
-	if err := os.WriteFile(filepath.Join(configDir, falcoDriverConfigFile), engineKind, 0o600); err != nil {
+	// #nosec G306 //under /etc we want 644 permissions
+	if err := os.WriteFile(filepath.Join(configDir, falcoDriverConfigFile), engineKind, 0o644); err != nil {
 		return fmt.Errorf("unable to persist engine kind to filesystem: %w", err)
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

Falco config files are not supposed to contain sensitive information, so read permissions are given to all users. With this fix, the permissions of the config file for the driver engine override will be aligned to other Falco configs files under `/etc/falco`.

**Which issue(s) this PR fixes**:

The issue was discovered with falcoctl 0.10, which is bundled with Falco 0.39

**Special notes for your reviewer**:
cc @alacuku 