### PR TITLE
fix(auth/gcp): ensure correct OAuth scope for Artifact Registry with service account

### DIFF
--- a/internal/login/gcp/gcp.go
+++ b/internal/login/gcp/gcp.go
@@ -28,7 +28,7 @@ import (
 // Login checks if passed gcp credentials are correct.
 func Login(ctx context.Context, reg string) error {
 	// Check that we can find a valid token source using GCE or ApplicationDefault.
-	ts, err := google.DefaultTokenSource(ctx)
+	ts, err := google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform")
 	if err != nil {
 		return fmt.Errorf("wrong GCP token source, unable to find a valid source: %w", err)
 	}

--- a/pkg/oci/authn/gcp.go
+++ b/pkg/oci/authn/gcp.go
@@ -55,7 +55,7 @@ func GCPCredential(ctx context.Context, reg string) (auth.Credential, error) {
 
 	// load saved tokenSource or saves it
 	if SavedTokenSource == nil {
-		tokenSource, err = google.DefaultTokenSource(ctx)
+		tokenSource, err = google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform")
 		if err != nil {
 			return auth.EmptyCredential, fmt.Errorf("error while trying to identify a GCP TokenSource %w", err)
 		}


### PR DESCRIPTION
Adjusted OAuth scope to `https://www.googleapis.com/auth/cloud-platform` for compatibility with both service account and Workload Identity setups, resolving invalid scope errors when accessing Artifact Registry.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the Falco `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

> /area cli

> /area tests

> /area examples

**What this PR does / why we need it**:
This PR fixes an issue with OAuth authentication when accessing Google Artifact Registry using a service account. By ensuring the correct scope (https://www.googleapis.com/auth/cloud-platform) is specified, this update resolves token retrieval errors and makes the authentication process compatible with both service account and Workload Identity configurations. This fix is essential for smooth integration with Artifact Registry, especially in environments leveraging Workload Identity on GKE.

**Which issue(s) this PR fixes**:



<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

