### PR TITLE
fix(follow): handle directories in tar.gz artifacts

### DIFF
--- a/internal/utils/extract.go
+++ b/internal/utils/extract.go
@@ -86,7 +86,6 @@ func ExtractTarGz(ctx context.Context, gzipStream io.Reader, destDir string, str
 			continue
 		}
 		info := header.FileInfo()
-		files = append(files, path)
 
 		switch header.Typeflag {
 		case tar.TypeDir:
@@ -106,6 +105,7 @@ func ExtractTarGz(ctx context.Context, gzipStream io.Reader, destDir string, str
 			if err = outFile.Close(); err != nil {
 				return nil, err
 			}
+			files = append(files, path)
 		case tar.TypeLink:
 			name := header.Linkname
 			if stripPathComponents > 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the Falco `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area cli

**What this PR does / why we need it**:

A bit of background on my use-case:

I've configured Falco to load all rules from a given sub-directory within `/etc/falco`, e.g.: `/etc/falco/subdir/rules1.yaml`, and packaged multiple rules files into separate `rulesfile` artifacts in `tar.gz` format.

During packaging, I'll generate the final directory structure I want and archive it, knowing that `falcoctl artifact` will extract the contents onto `/etc/falco`.

The issue is that while `falco artifact install` works great, `falco artifact follow` seems to break when processing the file path as it expects base paths to always be files, so it'll always fail when the rules gets updated and then it tries to move a directory.

**Which issue(s) this PR fixes**:

This PR addresses the issue above by modifying the file path handling in a way that preserves the artifact directory structure, and also slightly modifies the tar.gz extraction logic by only appending to `files` if it's handling an actual file and not a directory/symlink.

I've added tests for these use cases to ensure that the previous behavior remains unchanged.

The error below is printed when trying to update an artifact pushed as `.tar.gz`, that includes the file: `/rules.csq.d/kubernetes.yaml`, which gets installed at `/etc/falco/rules.csq.d/kubernetes.yaml` (because `/rulesfiles` is mounted at `/etc/falco` by the Helm chart).

```json
{
    "destDirectory": "/rulesfiles",
    "fileName": "rules.csq.d",
    "followerName": "foobar/falco-rules/platform:1-kubernetes",
    "level": "ERROR",
    "msg": "Unable to move file",
    "reason": "unable to read file /tmp/falcoctl-1880591248/rules.csq.d: read /tmp/falcoctl-1880591248/rules.csq.d: is a directory",
    "timestamp": "2025-01-14 17:03:32"
}
```

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->
