### PR TITLE
Feat insecure auth flag

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -161,6 +161,7 @@ type BasicAuth struct {
 	Registry string `mapstructure:"registry"`
 	User     string `mapstructure:"user"`
 	Password string `mapstructure:"password"`
+	Insecure bool   `mapstructure:"insecure"`
 }
 
 // GcpAuth represents a Gcp activation setting.

--- a/internal/login/basic/basic.go
+++ b/internal/login/basic/basic.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Login checks if passed credentials are correct and stores them.
-func Login(ctx context.Context, client *auth.Client, credStore credentials.Store, reg, username, password string) error {
+func Login(ctx context.Context, client *auth.Client, credStore credentials.Store, reg, username, password string, insecure bool) error {
 	cred := auth.Credential{
 		Username: username,
 		Password: password,
@@ -34,7 +34,7 @@ func Login(ctx context.Context, client *auth.Client, credStore credentials.Store
 
 	client.Credential = auth.StaticCredential(reg, cred)
 
-	r, err := registry.NewRegistry(reg, registry.WithClient(client))
+	r, err := registry.NewRegistry(reg, registry.WithClient(client), registry.WithInsecure(insecure))
 	if err != nil {
 		return err
 	}

--- a/internal/login/basic/basic_test.go
+++ b/internal/login/basic/basic_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package basic
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2/registry/remote/auth"
+)
+
+// mockCredentialStore is a mock implementation of the credentials.Store interface
+type mockCredentialStore struct {
+	putErr error
+}
+
+func (m *mockCredentialStore) Put(ctx context.Context, host string, cred auth.Credential) error {
+	return m.putErr
+}
+
+func (m *mockCredentialStore) Delete(ctx context.Context, host string) error {
+	return nil
+}
+
+func (m *mockCredentialStore) Get(ctx context.Context, host string) (auth.Credential, error) {
+	return auth.EmptyCredential, nil
+}
+
+func TestLogin(t *testing.T) {
+	// Create a test server that simulates a registry
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	// Create HTTP server for insecure tests
+	httpServer := httptest.NewServer(handler)
+	defer httpServer.Close()
+
+	// Create HTTPS server for secure tests
+	httpsServer := httptest.NewTLSServer(handler)
+	defer httpsServer.Close()
+
+	// Configure HTTP client to trust the test server's certificate
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: true,
+	}
+
+	tests := []struct {
+		name           string
+		registry       string
+		username       string
+		password       string
+		insecure       bool
+		putErr         error
+		expectedErr    error
+		expectedErrMsg string
+	}{
+		{
+			name:           "successful login with secure connection",
+			registry:       httpsServer.URL[8:], // Remove "https://" prefix
+			username:       "testuser",
+			password:       "testpass",
+			insecure:       false,
+			putErr:         nil,
+			expectedErr:    nil,
+			expectedErrMsg: "",
+		},
+		{
+			name:           "successful login with insecure connection",
+			registry:       httpServer.URL[7:], // Remove "http://" prefix
+			username:       "testuser",
+			password:       "testpass",
+			insecure:       true,
+			putErr:         nil,
+			expectedErr:    nil,
+			expectedErrMsg: "",
+		},
+		{
+			name:           "failed credential store put",
+			registry:       httpsServer.URL[8:], // Remove "https://" prefix
+			username:       "testuser",
+			password:       "testpass",
+			insecure:       false,
+			putErr:         errors.New("failed to store credentials"),
+			expectedErr:    errors.New("unable to save credentials in credential store: failed to store credentials"),
+			expectedErrMsg: "unable to save credentials in credential store: failed to store credentials",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock credential store
+			mockStore := &mockCredentialStore{
+				putErr: tt.putErr,
+			}
+
+			// Create auth client
+			client := &auth.Client{}
+
+			// Create context
+			ctx := context.Background()
+
+			// Call Login
+			err := Login(ctx, client, mockStore, tt.registry, tt.username, tt.password, tt.insecure)
+
+			// Check error
+			if tt.expectedErr != nil {
+				require.Error(t, err)
+				assert.Equal(t, tt.expectedErrMsg, err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+} 

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -78,7 +78,7 @@ func PerformBasicAuthsLogin(
 ) error {
 	for _, basicAuth := range auths {
 		if _, exists := registrySet[basicAuth.Registry]; exists {
-			if err := basic.Login(ctx, client, credStore, basicAuth.Registry, basicAuth.User, basicAuth.Password); err != nil {
+			if err := basic.Login(ctx, client, credStore, basicAuth.Registry, basicAuth.User, basicAuth.Password, basicAuth.Insecure); err != nil {
 				return err
 			}
 		}

--- a/pkg/oci/authn/client.go
+++ b/pkg/oci/authn/client.go
@@ -36,6 +36,7 @@ type Options struct {
 	CredentialsFuncs      []func(context.Context, string) (auth.Credential, error)
 	AutoLoginHandler      *AutoLoginHandler
 	ClientTokenCache      auth.Cache
+	Insecure             bool
 }
 
 // NewClient creates a new authenticated client to interact with a remote registry.
@@ -149,5 +150,12 @@ func WithStore(store credentials.Store) func(c *Options) {
 func WithClientTokenCache(cache auth.Cache) func(c *Options) {
 	return func(c *Options) {
 		c.ClientTokenCache = cache
+	}
+}
+
+// WithInsecure sets the insecure option to skip TLS verification
+func WithInsecure(insecure bool) func(c *Options) {
+	return func(c *Options) {
+		c.Insecure = insecure
 	}
 }

--- a/pkg/oci/registry/registry.go
+++ b/pkg/oci/registry/registry.go
@@ -17,6 +17,7 @@ package registry
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -60,6 +61,22 @@ func WithClient(client remote.Client) func(r *Registry) {
 func WithPlainHTTP(plainHTTP bool) func(r *Registry) {
 	return func(r *Registry) {
 		r.PlainHTTP = plainHTTP
+	}
+}
+
+// WithInsecure sets both plain HTTP and skips TLS verification.
+func WithInsecure(insecure bool) func(r *Registry) {
+	return func(r *Registry) {
+		r.PlainHTTP = insecure
+		if insecure {
+			if httpClient, ok := r.Client.(*http.Client); ok {
+				httpClient.Transport = &http.Transport{
+					TLSClientConfig: &tls.Config{
+						InsecureSkipVerify: true,
+					},
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## New Feature

### Added `--insecure` flag to `registry auth basic` command
- Allows authentication to registries using plain HTTP (non-HTTPS) connections
- Useful for local development and testing with private registries
- Helps when working with registries that don't have TLS configured
- Example usage: `falcoctl registry auth basic -u username -p password localhost:5000 --insecure`

This feature makes it easier to work with local and development registries that don't have TLS certificates configured, improving the development workflow and testing capabilities.

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

area library

area cli

area tests

> /area examples

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
I tested this by created a local private registry and authenticated to it with the insecure tag and I was able to pull and pull from the registry:
```
./falcoctl registry auth basic -u testuser -p testpass localhost:5001 --config ~/.config/falcoctl/falcoctl.yaml --insecure

./falcoctl registry push --type plugin --version 0.2.1 --platform linux/amd64 localhost:5001/k8smeta:0.2.1 ~/.falco/plugins/libk8smeta.so --config ~/.config/falcoctl/falcoctl.yaml --plain-http

./falcoctl artifact install localhost:5001/k8smeta:0.2.1 --config ~/.config/falcoctl/falcoctl.yaml --platform linux/amd64 --plugins-dir ~/.falco/plugins-test --plain-http
```