### PR TITLE
Feat insecure auth flag

### DIFF
--- a/internal/utils/validate.go
+++ b/internal/utils/validate.go
@@ -22,6 +22,9 @@ import (
 
 // GetRegistryFromRef extracts the registry from a ref string.
 func GetRegistryFromRef(ref string) (string, error) {
+	// Remove scheme if present
+	ref = strings.TrimPrefix(strings.TrimPrefix(ref, "http://"), "https://")
+
 	index := strings.Index(ref, "/")
 	if index <= 0 {
 		return "", fmt.Errorf("cannot extract registry name from ref %q", ref)

--- a/pkg/oci/authn/client.go
+++ b/pkg/oci/authn/client.go
@@ -64,6 +64,7 @@ func NewClient(options ...func(*Options)) *auth.Client {
 	}
 
 	if opt.Insecure {
+		//nolint:gosec // InsecureSkipVerify is intentionally set to true when --insecure flag is used
 		transport.TLSClientConfig = &tls.Config{
 			InsecureSkipVerify: true,
 		}
@@ -161,7 +162,7 @@ func WithClientTokenCache(cache auth.Cache) func(c *Options) {
 	}
 }
 
-// WithInsecure configures the client to skip TLS verification
+// WithInsecure configures the client to skip TLS verification.
 func WithInsecure() func(c *Options) {
 	return func(c *Options) {
 		c.Insecure = true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the Falco `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

 feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

cli

tests

> /area examples

**What this PR does / why we need it**:

Added --insecure flag to registry auth basic command

- Allows authentication to registries using plain HTTP (non-HTTPS) connections
- Useful for local development and testing with private registries
- Helps when working with registries that don't have TLS configured
- Example usage: falcoctl registry auth basic -u username -p password localhost:5000 --insecure
- This feature makes it easier to work with local and development registries that don't have TLS certificates configured, improving the development workflow and testing capabilities.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
I tested this by created a local private registry and authenticated to it with the insecure tag and I was able to pull and pull from the registry:

```bash
docker run -d -p 5001:5000 --name registry1 registry:2  
./falcoctl registry auth basic --insecure -u testuser -p testpass --config ~/.falcoctl/config.yaml http://localhost:5001
```

