### PR TITLE
fix(install): fix resource leak during artifact extraction and improve dependency error messages

### DIFF
--- a/cmd/artifact/install/deps.go
+++ b/cmd/artifact/install/deps.go
@@ -140,7 +140,7 @@ func ResolveDeps(configResolver artifactConfigResolver, resolver refResolver, in
 					if existing.ver.Major != alternativeVer.Major {
 						return nil, fmt.Errorf(
 							`%w: %s depends on %s:%s but an incompatible version %s:%s is required by other artifacts`,
-							ErrCannotSatisfyDependencies, name, required.Name, required.Version, required.Name, existing.ver.String(),
+							ErrCannotSatisfyDependencies, name, required.Name, required.Version, alternative.Name, existing.ver.String(),
 						)
 					}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the Falco `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

This PR fixes three issues in the artifact install command:

1. **File descriptor leak during artifact extraction**: The file handle opened for reading the artifact tarball was never closed, causing resource leaks when installing multiple artifacts in sequence. This could lead to "too many open files" errors in scenarios where many artifacts are installed.

2. **Missing config field in ArtifactInfo**: The `prepareArtifactList` method was not populating the `config` field when creating `ArtifactInfo` structs, leading to inconsistency with the `ResolveDeps` function. While this didn't cause immediate issues, it could lead to nil pointer dereferences in future code changes.

3. **Incorrect error message for alternative dependencies**: When reporting incompatible alternative dependencies, the error message was displaying the required dependency name twice instead of showing the actual alternative artifact name, making debugging more difficult.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

The config field population ensures consistency between the two code paths that create `ArtifactInfo` structs (`prepareArtifactList` when `resolveDeps=false` and `ResolveDeps` when `resolveDeps=true`). Currently, the config field is not accessed after `prepareArtifactList` returns, so this is a preventive fix.