### PR TITLE
fix(signature): pass registry credentials to cosign for signature verification 

### DIFF
--- a/cmd/artifact/install/install.go
+++ b/cmd/artifact/install/install.go
@@ -297,7 +297,7 @@ func (o *artifactInstallOptions) RunArtifactInstall(ctx context.Context, args []
 			digestRef := fmt.Sprintf("%s@%s", repo, result.RootDigest)
 
 			logger.Info("Verifying signature for artifact", logger.Args("digest", digestRef))
-			err = signature.Verify(ctx, digestRef, sig)
+			err = signature.Verify(ctx, digestRef, sig, o.PlainHTTP)
 			if err != nil {
 				return fmt.Errorf("error while verifying signature for %s: %w", digestRef, err)
 			}

--- a/cmd/registry/auth/basic/basic.go
+++ b/cmd/registry/auth/basic/basic.go
@@ -26,7 +26,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/term"
-	"oras.land/oras-go/v2/registry/remote/credentials"
 
 	"github.com/falcosecurity/falcoctl/internal/config"
 	"github.com/falcosecurity/falcoctl/internal/login/basic"
@@ -110,11 +109,9 @@ func (o *loginOptions) RunBasic(ctx context.Context, args []string) error {
 	client := authn.NewClient()
 
 	// create credential store
-	credentialStore, err := credentials.NewStore(config.RegistryCredentialConfPath(), credentials.StoreOptions{
-		AllowPlaintextPut: true,
-	})
+	credentialStore, err := authn.NewCredentialStore()
 	if err != nil {
-		return fmt.Errorf("unable to create new store: %w", err)
+		return fmt.Errorf("unable to create credential store: %w", err)
 	}
 
 	if err := basic.Login(ctx, client, credentialStore, reg, o.username, o.password); err != nil {

--- a/internal/cosign/verify.go
+++ b/internal/cosign/verify.go
@@ -112,6 +112,11 @@ func (c *VerifyCommand) DoVerify(ctx context.Context, images []string) (err erro
 		return fmt.Errorf("constructing client options: %w", err)
 	}
 
+	// Allow HTTP registries when configured
+	if c.AllowHTTPRegistry || c.AllowInsecure {
+		c.NameOptions = append(c.NameOptions, name.Insecure)
+	}
+
 	co := &cosign.CheckOpts{
 		Annotations:                  c.Annotations.Annotations,
 		RegistryClientOpts:           ociremoteOpts,

--- a/internal/follower/follower.go
+++ b/internal/follower/follower.go
@@ -387,7 +387,8 @@ func (f *Follower) pull(ctx context.Context) (filePaths []string, res *oci.Regis
 	// Verify the signature if needed
 	if f.Config.Signature != nil {
 		f.logger.Debug("Verifying signature", f.logger.Args("followerName", f.ref, "digest", digestRef))
-		err = signature.Verify(ctx, digestRef, f.Config.Signature)
+		//nolint:staticcheck // Ignore QF1008: we want to keep embedded config.Signature field
+		err = signature.Verify(ctx, digestRef, f.Config.Signature, f.Config.PlainHTTP)
 		if err != nil {
 			return filePaths, res, fmt.Errorf("could not verify signature for %s: %w", res.RootDigest, err)
 		}

--- a/internal/signature/signature_test.go
+++ b/internal/signature/signature_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestVerify_NilSignature(t *testing.T) {
 	ctx := context.Background()
-	err := Verify(ctx, "ghcr.io/test/image:latest", nil)
+	err := Verify(ctx, "ghcr.io/test/image:latest", nil, false)
 	if err != nil {
 		t.Errorf("Verify with nil signature should return nil, got: %v", err)
 	}
@@ -35,7 +35,7 @@ func TestVerify_NilCosign(t *testing.T) {
 	sig := &index.Signature{
 		Cosign: nil,
 	}
-	err := Verify(ctx, "ghcr.io/test/image:latest", sig)
+	err := Verify(ctx, "ghcr.io/test/image:latest", sig, false)
 	if err != nil {
 		t.Errorf("Verify with nil Cosign should return nil, got: %v", err)
 	}
@@ -50,7 +50,7 @@ func TestVerify_EmptyRef(t *testing.T) {
 		},
 	}
 	// Empty ref should fail during parsing
-	err := Verify(ctx, "", sig)
+	err := Verify(ctx, "", sig, false)
 	if err == nil {
 		t.Error("Verify with empty ref should return an error")
 	}
@@ -65,8 +65,78 @@ func TestVerify_InvalidRef(t *testing.T) {
 		},
 	}
 	// Invalid ref should fail during parsing
-	err := Verify(ctx, "not a valid ref!!!", sig)
+	err := Verify(ctx, "not a valid ref!!!", sig, false)
 	if err == nil {
 		t.Error("Verify with invalid ref should return an error")
+	}
+}
+
+func TestVerify_PlainHTTP(t *testing.T) {
+	ctx := context.Background()
+	sig := &index.Signature{
+		Cosign: &index.CosignSignature{
+			CertificateOidcIssuer: "https://token.actions.githubusercontent.com",
+			CertificateIdentity:   "test@example.com",
+		},
+	}
+	// This should create keychain and set plainHTTP options correctly
+	// It will fail because the image doesn't exist, but the keychain creation should work
+	err := Verify(ctx, "localhost:5000/test/image:latest", sig, true)
+	// We expect an error (image doesn't exist), but not a keychain creation error
+	if err == nil {
+		t.Error("Verify should fail for non-existent image")
+	}
+	// The error should be about the image not existing, not about keychain
+	if err != nil && err.Error() == "failed to create keychain" {
+		t.Errorf("Verify should not fail on keychain creation: %v", err)
+	}
+}
+
+func TestVerify_WithKeyRef(t *testing.T) {
+	ctx := context.Background()
+	sig := &index.Signature{
+		Cosign: &index.CosignSignature{
+			KeyRef: "cosign.pub",
+		},
+	}
+	// This tests that KeyRef is properly passed to cosign
+	err := Verify(ctx, "ghcr.io/test/image:latest", sig, false)
+	// We expect an error (image doesn't exist), but the signature config should be valid
+	if err == nil {
+		t.Error("Verify should fail for non-existent image")
+	}
+}
+
+func TestVerify_WithIgnoreTlog(t *testing.T) {
+	ctx := context.Background()
+	sig := &index.Signature{
+		Cosign: &index.CosignSignature{
+			CertificateOidcIssuer: "https://token.actions.githubusercontent.com",
+			CertificateIdentity:   "test@example.com",
+			IgnoreTlog:            true,
+		},
+	}
+	// This tests that IgnoreTlog is properly passed to cosign
+	err := Verify(ctx, "ghcr.io/test/image:latest", sig, false)
+	// We expect an error (image doesn't exist), but the signature config should be valid
+	if err == nil {
+		t.Error("Verify should fail for non-existent image")
+	}
+}
+
+func TestVerify_WithCertIdentityRegexp(t *testing.T) {
+	ctx := context.Background()
+	sig := &index.Signature{
+		Cosign: &index.CosignSignature{
+			CertificateOidcIssuer:       "https://token.actions.githubusercontent.com",
+			CertificateIdentityRegexp:   ".*@example.com",
+			CertificateOidcIssuerRegexp: "https://token.actions.*",
+		},
+	}
+	// This tests that regexp options are properly passed to cosign
+	err := Verify(ctx, "ghcr.io/test/image:latest", sig, false)
+	// We expect an error (image doesn't exist), but the signature config should be valid
+	if err == nil {
+		t.Error("Verify should fail for non-existent image")
 	}
 }

--- a/pkg/oci/authn/client.go
+++ b/pkg/oci/authn/client.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 The Falco Authors
+// Copyright (C) 2026 The Falco Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@ import (
 
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/credentials"
+
+	"github.com/falcosecurity/falcoctl/internal/config"
 )
 
 const (
@@ -150,4 +152,12 @@ func WithClientTokenCache(cache auth.Cache) func(c *Options) {
 	return func(c *Options) {
 		c.ClientTokenCache = cache
 	}
+}
+
+// NewCredentialStore creates a new credential store using falcoctl's configuration.
+// This is the single source of truth for creating credential stores in falcoctl.
+func NewCredentialStore() (credentials.Store, error) {
+	return credentials.NewStore(config.RegistryCredentialConfPath(), credentials.StoreOptions{
+		AllowPlaintextPut: true,
+	})
 }

--- a/pkg/oci/authn/keychain.go
+++ b/pkg/oci/authn/keychain.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authn
+
+import (
+	"context"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/v1/google"
+	"golang.org/x/exp/slices"
+	"oras.land/oras-go/v2/registry/remote/credentials"
+
+	"github.com/falcosecurity/falcoctl/internal/config"
+)
+
+// Keychain implements authn.Keychain using the same authentication
+// sources that falcoctl uses for pulling artifacts:
+// 1. Falcoctl credential store (from falcoctl registry auth basic).
+// 2. OAuth2 client credentials (from falcoctl's config).
+// 3. GCP credentials (for registries configured with falcoctl registry auth gcp).
+type Keychain struct {
+	credentialStore credentials.Store
+	oauthStore      OAuthClientCredentialsStore
+}
+
+// NewKeychain creates a new keychain that uses falcoctl's authentication sources.
+func NewKeychain() (*Keychain, error) {
+	credentialStore, err := NewCredentialStore()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Keychain{
+		credentialStore: credentialStore,
+		oauthStore:      NewOauthClientCredentialsStore(),
+	}, nil
+}
+
+// Resolve implements authn.Keychain.
+func (k *Keychain) Resolve(resource authn.Resource) (authn.Authenticator, error) {
+	ctx := context.Background()
+	registry := resource.RegistryStr()
+
+	// 1. Try credential store (from falcoctl registry auth basic)
+	cred, err := k.credentialStore.Get(ctx, registry)
+	if err == nil && (cred.Username != "" || cred.AccessToken != "") {
+		if cred.AccessToken != "" {
+			return authn.FromConfig(authn.AuthConfig{
+				RegistryToken: cred.AccessToken,
+			}), nil
+		}
+		return authn.FromConfig(authn.AuthConfig{
+			Username: cred.Username,
+			Password: cred.Password,
+		}), nil
+	}
+
+	// 2. Try OAuth2 client credentials
+	oauthCred, err := k.oauthStore.Credential(ctx, registry)
+	if err == nil && oauthCred.AccessToken != "" {
+		return authn.FromConfig(authn.AuthConfig{
+			RegistryToken: oauthCred.AccessToken,
+		}), nil
+	}
+
+	// 3. Try GCP credentials (for registries configured with falcoctl registry auth gcp)
+	if isGCPRegistry(registry) {
+		return google.Keychain.Resolve(resource)
+	}
+
+	// No credentials found
+	return authn.Anonymous, nil
+}
+
+// isGCPRegistry checks if the registry is configured for GCP authentication
+// in falcoctl's configuration (via falcoctl registry auth gcp).
+func isGCPRegistry(registry string) bool {
+	gcpAuths, err := config.Gcps()
+	if err != nil {
+		return false
+	}
+
+	idx := slices.IndexFunc(gcpAuths, func(c config.GcpAuth) bool {
+		return c.Registry == registry
+	})
+
+	return idx != -1
+}

--- a/pkg/oci/utils/utils.go
+++ b/pkg/oci/utils/utils.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 The Falco Authors
+// Copyright (C) 2026 The Falco Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,9 +21,7 @@ import (
 
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
-	"oras.land/oras-go/v2/registry/remote/credentials"
 
-	"github.com/falcosecurity/falcoctl/internal/config"
 	"github.com/falcosecurity/falcoctl/pkg/oci/authn"
 	ocipuller "github.com/falcosecurity/falcoctl/pkg/oci/puller"
 	ocipusher "github.com/falcosecurity/falcoctl/pkg/oci/pusher"
@@ -53,11 +51,9 @@ func Pusher(plainHTTP bool, printer *output.Printer) (*ocipusher.Pusher, error) 
 // Client returns a new auth.Client.
 // It authenticates the client if credentials are found in the system.
 func Client(enableClientTokenCache bool) (remote.Client, error) {
-	credentialStore, err := credentials.NewStore(config.RegistryCredentialConfPath(), credentials.StoreOptions{
-		AllowPlaintextPut: true,
-	})
+	credentialStore, err := authn.NewCredentialStore()
 	if err != nil {
-		return nil, fmt.Errorf("unable to create new store: %w", err)
+		return nil, fmt.Errorf("unable to create credential store: %w", err)
 	}
 
 	// create client that


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the Falco `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area library

/area cli

> /area tests

> /area examples

**What this PR does / why we need it**:

This PR fixes signature verification failing on authenticated registries by passing falcoctl's credentials to cosign.

Previously, when verifying signatures on private/authenticated registries, cosign would fail because it didn't have access to the credentials that falcoctl uses for pulling artifacts. This caused signature verification to fail with authentication errors even though the artifact pull itself succeeded.

The keychain uses the same authentication sources as the rest of falcoctl:
1. Credential store (falcoctl registry auth basic)
2. OAuth2 client credentials
3. GCP credentials (falcoctl registry auth gcp)

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #884

**Special notes for your reviewer**:
