### PR TITLE
utils: reject symlink and hardlink entries in ExtractTarGz

### DIFF
--- a/internal/utils/extract.go
+++ b/internal/utils/extract.go
@@ -28,19 +28,12 @@ import (
 	"golang.org/x/net/context"
 )
 
-type link struct {
-	Name string
-	Path string
-}
-
 // ExtractTarGz extracts a *.tar.gz compressed archive and moves its content to destDir.
 // Returns a slice containing the full path of the extracted files.
 func ExtractTarGz(ctx context.Context, gzipStream io.Reader, destDir string, stripPathComponents int) ([]string, error) {
 	var (
-		files    []string
-		links    []link
-		symlinks []link
-		err      error
+		files []string
+		err   error
 	)
 
 	// We need an absolute path
@@ -106,46 +99,16 @@ func ExtractTarGz(ctx context.Context, gzipStream io.Reader, destDir string, str
 				return nil, err
 			}
 			files = append(files, path)
-		case tar.TypeLink:
-			name := header.Linkname
-			if stripPathComponents > 0 {
-				name = stripComponents(name, stripPathComponents)
-			}
-			if name == "" {
-				continue
-			}
-
-			name = filepath.Join(destDir, filepath.Clean(name))
-			links = append(links, link{Path: path, Name: name})
-		case tar.TypeSymlink:
-			symlinks = append(symlinks, link{Path: path, Name: header.Linkname})
+		case tar.TypeSymlink, tar.TypeLink:
+			// Artifacts do not need symlink or hardlink entries, and an unvalidated
+			// link target can point outside destDir: the ".." check above only
+			// inspects header.Name, never header.Linkname. Reject link entries.
+			return nil, fmt.Errorf("link entries are not allowed in artifact archives: %q -> %q", header.Name, header.Linkname)
 		default:
 			return nil, fmt.Errorf("extractTarGz: uknown type: %b in %s", header.Typeflag, header.Name)
 		}
 	}
 
-	// Now we make another pass creating the links
-	for i := range links {
-		select {
-		case <-ctx.Done():
-			return nil, errors.New("interrupted")
-		default:
-		}
-		if err = os.Link(links[i].Name, links[i].Path); err != nil {
-			return nil, err
-		}
-	}
-
-	for i := range symlinks {
-		select {
-		case <-ctx.Done():
-			return nil, errors.New("interrupted")
-		default:
-		}
-		if err = os.Symlink(symlinks[i].Name, symlinks[i].Path); err != nil {
-			return nil, err
-		}
-	}
 	return files, nil
 }
 

--- a/internal/utils/extract_test.go
+++ b/internal/utils/extract_test.go
@@ -17,6 +17,7 @@ package utils
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"io"
 	"os"
@@ -206,5 +207,38 @@ func TestExtractTarGzStripComponents(t *testing.T) {
 		ff := strings.TrimPrefix(f, srcDir)
 		path := filepath.Join(absDestDirStrip, ff)
 		assert.Contains(t, list, path)
+	}
+}
+
+func TestExtractTarGz_RejectsLinkEntries(t *testing.T) {
+	build := func(h *tar.Header) io.Reader {
+		var buf bytes.Buffer
+		gz := gzip.NewWriter(&buf)
+		tw := tar.NewWriter(gz)
+		if err := tw.WriteHeader(h); err != nil {
+			t.Fatal(err)
+		}
+		if err := tw.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := gz.Close(); err != nil {
+			t.Fatal(err)
+		}
+		return &buf
+	}
+	cases := []struct {
+		name  string
+		entry *tar.Header
+	}{
+		{"symlink", &tar.Header{Name: "evil", Typeflag: tar.TypeSymlink, Linkname: "/etc/passwd", Mode: 0o777}},
+		{"hardlink", &tar.Header{Name: "leak", Typeflag: tar.TypeLink, Linkname: "../secret", Mode: 0o644}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ExtractTarGz(context.Background(), build(tc.entry), t.TempDir(), 0)
+			if err == nil || !strings.Contains(err.Error(), "link entries are not allowed") {
+				t.Fatalf("expected %s entry to be rejected, got err: %v", tc.name, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/area library

**What this PR does / why we need it**:

`ExtractTarGz` (`internal/utils/extract.go`) contains extracted regular files to `destDir` (the `..` check on `header.Name` plus `safeConcat` from #228), but it does not validate link targets. A hardlink target is joined as `filepath.Join(destDir, filepath.Clean(linkname))`, and `filepath.Clean` keeps a leading `../`, so the target can resolve outside `destDir`. A symlink target (`header.Linkname`) is passed to `os.Symlink` unchanged, so an absolute or `../` target is accepted. Because artifact install directories (`PluginsDir`, `RulesfilesDir`, `AssetsDir`) are reused across installs, a planted escaping symlink can be written through by a later extraction.

Following a private report and discussion with the maintainers, this hardens the extractor by rejecting symlink and hardlink entries outright. Falco artifacts do not need link entries, so refusing them is the simplest correct fix and removes the unvalidated-link-target surface entirely.

**Which issue(s) this PR fixes**:

N/A. Addresses a hardening item reported privately and coordinated with the maintainers.

**Special notes for your reviewer**:

- The change removes the two link-creation passes and the now-unused `link` struct plus the `links` / `symlinks` slices; `ExtractTarGz` now handles directories and regular files and returns an error on any symlink or hardlink entry.
- Added `TestExtractTarGz_RejectsLinkEntries` covering both a symlink and a hardlink entry; the existing `TestExtractTarGz` and `TestExtractTarGzStripComponents` still pass.
- Possible follow-up (not in this PR): because install dirs are shared across runs and `safeConcat` is string-only, a symlink planted by an older client could still be followed on a later regular-file write. Opening regular files with `O_NOFOLLOW` (or an `lstat` per component) would close that residual. Happy to do that separately if you want it.

```release-note
Reject symlink and hardlink entries during artifact extraction to remove an unvalidated link-target path-traversal surface.
```