### PR TITLE
utils: reject extraction through pre-existing symlinks in dest

### DIFF
--- a/internal/utils/extract.go
+++ b/internal/utils/extract.go
@@ -91,10 +91,10 @@ func ExtractTarGz(ctx context.Context, gzipStream io.Reader, destDir string, str
 			// under destDir, is a pre-existing symlink, so extraction cannot be
 			// redirected outside destDir. On unix O_NOFOLLOW below also stops the
 			// final component from being followed race-free.
-			if err = checkNoSymlinkTraversal(destDir, path); err != nil {
+			if err := checkNoSymlinkTraversal(destDir, path); err != nil {
 				return nil, err
 			}
-			outFile, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC|oNoFollow, info.Mode())
+			outFile, err := os.OpenFile(filepath.Clean(path), os.O_RDWR|os.O_CREATE|os.O_TRUNC|oNoFollow, info.Mode())
 			if err != nil {
 				return nil, err
 			}

--- a/internal/utils/extract.go
+++ b/internal/utils/extract.go
@@ -86,7 +86,15 @@ func ExtractTarGz(ctx context.Context, gzipStream io.Reader, destDir string, str
 				return nil, err
 			}
 		case tar.TypeReg:
-			outFile, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, info.Mode())
+			// safeConcat is a lexical join, so it does not resolve symlinks that
+			// already exist on disk. Reject a write whose target, or any parent
+			// under destDir, is a pre-existing symlink, so extraction cannot be
+			// redirected outside destDir. On unix O_NOFOLLOW below also stops the
+			// final component from being followed race-free.
+			if err = checkNoSymlinkTraversal(destDir, path); err != nil {
+				return nil, err
+			}
+			outFile, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC|oNoFollow, info.Mode())
 			if err != nil {
 				return nil, err
 			}
@@ -134,4 +142,38 @@ func safeConcat(destDir, name string) (string, error) {
 		return res, fmt.Errorf("unsafe path concatenation: '%s' with '%s'", destDir, name)
 	}
 	return res, nil
+}
+
+// checkNoSymlinkTraversal verifies that no path component between destDir and
+// target is an existing symlink. safeConcat only joins strings, so a symlink
+// already present in a shared install dir would otherwise be followed when a
+// regular file is written through it. Both destDir and target must be absolute
+// and cleaned, with target inside destDir. This is a defense-in-depth check
+// with a small TOCTOU window; on unix the O_NOFOLLOW flag closes the window on
+// the final component.
+func checkNoSymlinkTraversal(destDir, target string) error {
+	rel, err := filepath.Rel(destDir, target)
+	if err != nil {
+		return err
+	}
+	current := destDir
+	for _, part := range strings.Split(rel, string(os.PathSeparator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		current = filepath.Join(current, part)
+		fi, err := os.Lstat(current)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// This component does not exist yet, so nothing below it can
+				// either. There is no symlink to follow.
+				return nil
+			}
+			return err
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to extract %q through a pre-existing symlink %q", target, current)
+		}
+	}
+	return nil
 }

--- a/internal/utils/extract_nofollow_other.go
+++ b/internal/utils/extract_nofollow_other.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !unix
+
+package utils
+
+// oNoFollow is a no-op where O_NOFOLLOW is not available, for example Windows.
+// The checkNoSymlinkTraversal lstat guard still rejects pre-existing symlinks.
+const oNoFollow = 0

--- a/internal/utils/extract_nofollow_others.go
+++ b/internal/utils/extract_nofollow_others.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2024 The Falco Authors
+// Copyright (C) 2026 The Falco Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/utils/extract_nofollow_unix.go
+++ b/internal/utils/extract_nofollow_unix.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2024 The Falco Authors
+// Copyright (C) 2026 The Falco Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/utils/extract_nofollow_unix.go
+++ b/internal/utils/extract_nofollow_unix.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unix
+
+package utils
+
+import "syscall"
+
+// oNoFollow makes an open fail if the final path component is a symlink,
+// closing the race on that component. Available on unix only.
+const oNoFollow = syscall.O_NOFOLLOW

--- a/internal/utils/extract_test.go
+++ b/internal/utils/extract_test.go
@@ -210,6 +210,78 @@ func TestExtractTarGzStripComponents(t *testing.T) {
 	}
 }
 
+// buildRegFileTarGz returns an in-memory .tar.gz with a single regular-file
+// entry (name, content). Used to drive ExtractTarGz against a pre-planted
+// symlink in the destination.
+func buildRegFileTarGz(t *testing.T, name, content string) io.Reader {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	hdr := &tar.Header{
+		Name:     name,
+		Typeflag: tar.TypeReg,
+		Mode:     0o644,
+		Size:     int64(len(content)),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.WriteString(tw, content); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return &buf
+}
+
+func TestExtractTarGz_RejectsPreExistingSymlink(t *testing.T) {
+	// Case A: the final path component is a pre-existing symlink pointing outside
+	// destDir. safeConcat is lexical, so without the on-disk symlink guard the
+	// regular-file open would follow it and write to the canary outside dest.
+	t.Run("final-component", func(t *testing.T) {
+		dest := t.TempDir()
+		outside := t.TempDir()
+		canary := filepath.Join(outside, "target")
+
+		if err := os.Symlink(canary, filepath.Join(dest, "evil")); err != nil {
+			t.Skipf("cannot create symlink on this platform: %v", err)
+		}
+
+		_, err := ExtractTarGz(context.Background(), buildRegFileTarGz(t, "evil", "pwned"), dest, 0)
+		if err == nil {
+			t.Fatalf("expected extraction through pre-existing symlink to be rejected, got nil error")
+		}
+		if _, statErr := os.Stat(canary); !os.IsNotExist(statErr) {
+			t.Fatalf("canary %q was written through the symlink (stat err: %v)", canary, statErr)
+		}
+	})
+
+	// Case B: a parent path component is a pre-existing symlink pointing outside
+	// destDir. The write of evildir/payload would otherwise land in outside/payload.
+	t.Run("parent-component", func(t *testing.T) {
+		dest := t.TempDir()
+		outside := t.TempDir()
+		canary := filepath.Join(outside, "payload")
+
+		if err := os.Symlink(outside, filepath.Join(dest, "evildir")); err != nil {
+			t.Skipf("cannot create symlink on this platform: %v", err)
+		}
+
+		_, err := ExtractTarGz(context.Background(), buildRegFileTarGz(t, "evildir/payload", "pwned2"), dest, 0)
+		if err == nil {
+			t.Fatalf("expected extraction through pre-existing parent symlink to be rejected, got nil error")
+		}
+		if _, statErr := os.Stat(canary); !os.IsNotExist(statErr) {
+			t.Fatalf("canary %q was written through the parent symlink (stat err: %v)", canary, statErr)
+		}
+	})
+}
+
 func TestExtractTarGz_RejectsLinkEntries(t *testing.T) {
 	build := func(h *tar.Header) io.Reader {
 		var buf bytes.Buffer


### PR DESCRIPTION
/kind cleanup

/area library

**What this PR does / why we need it**:

Follow-up to #1035, per @leogr's review comment there.

`safeConcat` is lexical, so a symlink already sitting in one of the install dirs still gets followed by the `os.OpenFile` in the `TypeReg` case, and the write ends up outside the dest. This lstat-checks each component under the dest root, and opens with `O_NOFOLLOW` on unix (build-tagged, Windows just gets the lstat path).

Test plants a symlink pointing outside dest and checks a regular file entry doesn't get written through it, both when the symlink is the leaf and when it's a parent dir. The link-entry rejection from #1035 is untouched.

Defense in depth really, since after #1035 you can't get such a symlink in through the archive anyway.

**Which issue(s) this PR fixes**:

Fixes #1036

**Notes**:

Went with lstat plus `O_NOFOLLOW` instead of pulling in securejoin, keeps the diff small and works on all three platforms. lstat alone has a TOCTOU window, hence the `O_NOFOLLOW` on unix. Happy to switch if you'd rather.

```release-note
utils: reject extracting a regular file through a pre-existing symlink in the destination directory
```
