### PR TITLE
wip: add falcoconfig OCI artifact type

### DIFF
--- a/cmd/artifact/follow/follow.go
+++ b/cmd/artifact/follow/follow.go
@@ -348,6 +348,7 @@ func (o *artifactFollowOptions) RunArtifactFollow(ctx context.Context, args []st
 			RulesfilesDir:     o.RulesfilesDir,
 			PluginsDir:        o.PluginsDir,
 			AssetsDir:         o.AssetsDir,
+			FalcoconfigDir:    o.FalcoconfigDir,
 			StateDir:          o.StateDir,
 			ArtifactReference: ref,
 			PlainHTTP:         o.PlainHTTP,

--- a/cmd/artifact/install/install.go
+++ b/cmd/artifact/install/install.go
@@ -312,6 +312,8 @@ func (o *artifactInstallOptions) RunArtifactInstall(ctx context.Context, args []
 			destDir = o.RulesfilesDir
 		case oci.Asset:
 			destDir = o.AssetsDir
+		case oci.Falcoconfig:
+			destDir = o.FalcoconfigDir
 		default:
 			return fmt.Errorf("unrecognized result type %q while pulling artifact", result.Type)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -113,7 +113,7 @@ const (
 	// ArtifactFollowAssetsDirKey is the Viper key for follower "pluginsDir" configuration.
 	ArtifactFollowAssetsDirKey = "artifact.follow.assetsdir"
 	// ArtifactFollowFalcoconfigDirKey is the Viper key for follower "falcoconfigDir" configuration.
-	ArtifactFollowFalcoconfigsDirKey = "artifact.follow.falcoconfigdir"
+	ArtifactFollowFalcoconfigDirKey = "artifact.follow.falcoconfigdir"
 	// ArtifactFollowStateDirKey is the Viper key for follower "stateDir" configuration.
 	ArtifactFollowStateDirKey = "artifact.follow.statedir"
 	// ArtifactFollowTmpDirKey is the Viper key for follower "pluginsDir" configuration.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -71,6 +71,8 @@ const (
 	RulesfilesDir = "/etc/falco"
 	// AssetsDir default path where assets are installed.
 	AssetsDir = "/etc/falco/assets"
+	// FalcoconfigDir default path where falcoconfig are installed.
+	FalcoconfigDir = "/etc/falco/config.d"
 	// StateDir default path where artifact state is persisted.
 	StateDir = "/var/lib/falcoctl"
 	// FollowResync time interval how often it checks for newer version of the artifact.
@@ -110,6 +112,8 @@ const (
 	ArtifactFollowPluginsDirKey = "artifact.follow.pluginsdir"
 	// ArtifactFollowAssetsDirKey is the Viper key for follower "pluginsDir" configuration.
 	ArtifactFollowAssetsDirKey = "artifact.follow.assetsdir"
+	// ArtifactFollowFalcoconfigDirKey is the Viper key for follower "falcoconfigDir" configuration.
+	ArtifactFollowFalcoconfigsDirKey = "artifact.follow.falcoconfigdir"
 	// ArtifactFollowStateDirKey is the Viper key for follower "stateDir" configuration.
 	ArtifactFollowStateDirKey = "artifact.follow.statedir"
 	// ArtifactFollowTmpDirKey is the Viper key for follower "pluginsDir" configuration.
@@ -123,6 +127,8 @@ const (
 	ArtifactInstallPluginsDirKey = "artifact.install.pluginsdir"
 	// ArtifactInstallAssetsDirKey is the Viper key for installer "pluginsDir" configuration.
 	ArtifactInstallAssetsDirKey = "artifact.install.assetsdir"
+	// ArtifactInstallFalcoconfigDirKey is the Viper key for installer "falcoconfigDir" configuration.
+	ArtifactInstallFalcoconfigDirKey = "artifact.install.falcoconfigdir"
 	// ArtifactInstallStateDirKey is the Viper key for installer "stateDir" configuration.
 	ArtifactInstallStateDirKey = "artifact.install.statedir"
 	// ArtifactInstallResolveDepsKey is the Viper key for installer "resolveDeps" configuration.
@@ -566,6 +572,7 @@ func Installer() (Install, error) {
 		Artifacts:     artifacts,
 		RulesfilesDir: viper.GetString(ArtifactInstallRulesfilesDirKey),
 		PluginsDir:    viper.GetString(ArtifactInstallPluginsDirKey),
+		FalcoconfigDir:viper.GetString(ArtifactInstallFalcoconfigDirKey),
 		ResolveDeps:   viper.GetBool(ArtifactInstallResolveDepsKey),
 		NoVerify:      viper.GetBool(ArtifactNoVerifyKey),
 	}, nil

--- a/internal/follower/follower.go
+++ b/internal/follower/follower.go
@@ -439,6 +439,8 @@ func (f *Follower) destinationDir(res *oci.RegistryResult) string {
 		dir = f.RulesfilesDir
 	case oci.Asset:
 		dir = f.AssetsDir
+	case oci.Falcoconfig:
+		dir = f.FalcoconfigDir
 	}
 	return dir
 }

--- a/pkg/oci/constants.go
+++ b/pkg/oci/constants.go
@@ -35,6 +35,13 @@ const (
 	// FalcoAssetLayerMediaType is the MediaType for assets.
 	FalcoAssetLayerMediaType = "application/vnd.cncf.falco.asset.layer.v1+tar.gz"
 
+	// FalcoAssetConfigMediaType is the MediaType for asset's config layer.
+	FalcoConfigConfigMediaType = "application/vnd.cncf.falco.falcoconfig.config.v1+json"
+
+	// FalcoAssetLayerMediaType is the MediaType for assets.
+	FalcoConfigLayerMediaType = "application/vnd.cncf.falco.falcoconfig.layer.v1+tar.gz"
+
+
 	// DefaultTag is the default tag reference to be used when none is provided.
 	DefaultTag = "latest"
 )

--- a/pkg/oci/puller/puller.go
+++ b/pkg/oci/puller/puller.go
@@ -109,6 +109,8 @@ func (p *Puller) Pull(ctx context.Context, ref, destDir, os, arch string) (*oci.
 		artifactType = oci.Rulesfile
 	case oci.FalcoAssetLayerMediaType:
 		artifactType = oci.Asset
+	case oci.FalcoConfigLayerMediaType:
+		artifactType = oci.Falcoconfig
 	default:
 		return nil, fmt.Errorf("unknown media type: %q", manifest.Layers[0].MediaType)
 	}

--- a/pkg/oci/pusher/pusher.go
+++ b/pkg/oci/pusher/pusher.go
@@ -219,6 +219,8 @@ func (p *Pusher) storeMainLayer(ctx context.Context, fileStore *file.Store,
 		layerMediaType = oci.FalcoPluginLayerMediaType
 	case oci.Asset:
 		layerMediaType = oci.FalcoAssetLayerMediaType
+	case oci.Falcoconfig:
+		layerMediaType = oci.FalcoConfigLayerMediaType
 	default:
 		return nil, fmt.Errorf("unknown media type for main layer: %s", artifactType)
 	}
@@ -242,6 +244,8 @@ func (p *Pusher) storeConfigLayer(ctx context.Context, fileStore *file.Store,
 		layerMediaType = oci.FalcoPluginConfigMediaType
 	case oci.Asset:
 		layerMediaType = oci.FalcoAssetConfigMediaType
+	case oci.Falcoconfig:
+		layerMediaType = oci.FalcoConfigConfigMediaType
 	default:
 		return nil, fmt.Errorf("unknown media type for config layer: %s", artifactType)
 	}

--- a/pkg/oci/types.go
+++ b/pkg/oci/types.go
@@ -35,6 +35,8 @@ const (
 	Plugin ArtifactType = "plugin"
 	// Asset represents an artifact consumed by another plugin.
 	Asset ArtifactType = "asset"
+	// Falcoconfig represents a falcoconfig file consumed by falco
+	Falcoconfig ArtifactType = "falcoconfig"
 )
 
 // The following functions are necessary to use ArtifactType with Cobra.
@@ -47,11 +49,11 @@ func (e ArtifactType) String() string {
 // Set an ArtifactType.
 func (e *ArtifactType) Set(v string) error {
 	switch v {
-	case "rulesfile", "plugin", "asset":
+	case "rulesfile", "plugin", "asset", "falcoconfig":
 		*e = ArtifactType(v)
 		return nil
 	default:
-		return errors.New(`must be one of "rulesfile", "plugin", "asset"`)
+		return errors.New(`must be one of "rulesfile", "plugin", "asset", "falcoconfig"`)
 	}
 }
 
@@ -70,6 +72,8 @@ func (e *ArtifactType) ToMediaType() string {
 		return FalcoPluginLayerMediaType
 	case Asset:
 		return FalcoAssetLayerMediaType
+	case Falcoconfig:
+		return FalcoConfigLayerMediaType
 	}
 
 	// should never happen
@@ -86,6 +90,8 @@ func HumanReadableMediaType(s string) string {
 		return string(Plugin)
 	case FalcoAssetLayerMediaType:
 		return string(Asset)
+	case FalcoConfigLayerMediaType:
+		return string(Falcoconfig)
 	}
 
 	// If we do not have a match for a well known mediaType then we return the original mediaType.

--- a/pkg/options/artifact.go
+++ b/pkg/options/artifact.go
@@ -76,7 +76,7 @@ func (art *Artifact) AddFlags(cmd *cobra.Command) error {
 			"add the floating tags for the major and minor versions")
 
 		cmd.Flags().Var(&art.ArtifactType, "type",
-			`type of artifact to be pushed. Allowed values: "rulesfile", "plugin", "asset"`)
+			`type of artifact to be pushed. Allowed values: "rulesfile", "plugin", "asset", "falcoconfig"`)
 		if err := cmd.MarkFlagRequired("type"); err != nil {
 			// this should never happen.
 			return fmt.Errorf("unable to mark flag \"type\" as required: %w", err)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature


**Any specific area of the project related to this PR?**

**What this PR does / why we need it**:

This PR is related to the implementation of [\[Feature Request\] Introduce a falcoconfig Artifact type that falcoctl can track](https://github.com/falcosecurity/falcoctl/issues/904).

Implementation of this PR could be usefull to ease config, rules and plugin maintenance while falco is already running.
As descibed in [\[Feature Request\] Introduce a falcoconfig Artifact type that falcoctl can track](https://github.com/falcosecurity/falcoctl/issues/904) and in the comments section of https://github.com/falcosecurity/falcoctl/pull/309: 
>With the combination of 3 rulesfiles, plugins and falcoconfig artifacts in addition to the falco's 'watch_config_files: true' existing parameter , the containerized falco probe could become fully autonomous and self-sufficient in terms of updates and maintenance: no need for argoCD components or something equivalent to track config/rules/plugins updates.

**Which issue(s) this PR fixes**:

Fixes #904 

**Special notes for your reviewer**:

I'm not familiar with GO but i'd like to contribute at my humble level on this important and complex topic, using some kind of 'vibecoding': this is the reason of the incomplete/wip state of PR and in advance my apologies for the potential lack of rigor in code enhancement proposal.
